### PR TITLE
[ign-fuel-tools4] Update BitBucket links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-See the [Ignition Robotics contributing guide](https://bitbucket.org/ignitionrobotics/ign-gazebo/src/default/CONTRIBUTING.md).
+See the [Ignition Robotics contributing guide](https://ignitionrobotics.org/docs/all/contributing).

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,61 +3,61 @@
 ### Ignition Fuel Tools 4.X.X (20xx-xx-xx)
 
 1. Alphabetical listing of subcommands.
-    * [Pull request 65](https://github.com/ignitionrobotics/ign-fuel-tools/pull/65)
+    * [BitBucket pull request 65](https://github.com/ignitionrobotics/ign-fuel-tools/pull/65)
 
 ### Ignition Fuel Tools 4.1.0 (2020-02-27)
 
 1. Resource deletion CLI.
-    * [Pull request 119](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/119)
+    * [BitBucket pull request 119](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/119)
 
 1. Fetch files
-    * [Pull request 123](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/123)
+    * [BitBucket pull request 123](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/123)
 
 1. README and tutorial updates:
-    * [Pull request 113](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/113)
-    * [Pull request 114](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/114)
-    * [Pull request 115](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/115)
+    * [BitBucket pull request 113](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/113)
+    * [BitBucket pull request 114](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/114)
+    * [BitBucket pull request 115](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/115)
 
 ### Ignition Fuel Tools 4.0.0 (2019-12-10)
 
 1. Model upload CLI, resource metadata CLI, depend on ign-msgs5.
-    * [Pull request 108](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/108)
+    * [BitBucket pull request 108](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/108)
 
 ## Ignition Fuel Tools 3.x
 
 ### Ignition Fuel Tools 3.x.x (20xx-xx-xx)
 
 1. Print message when downloading a resource.
-    * [Pull request 102](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/102)
+    * [BitBucket pull request 102](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/102)
 
 1. Use `${YAML_TARGET}` instead of `YAML::YAML` imported target.
-    * [Pull request 103](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/103)
+    * [BitBucket pull request 103](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/103)
 
 1. Convert emissive map file path.
-    * [Pull request 105](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/105)
+    * [BitBucket pull request 105](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/105)
 
 1. Fix windows build with `popen` and `pclose` macros.
-    * [Pull request 109](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/109)
+    * [BitBucket pull request 109](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/109)
 
 1. Remove std::experimental for filesystem (support for VS2019).
-    * [Pull request 120](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/120)
+    * [BitBucket pull request 120](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/120)
 
 ### Ignition Fuel Tools 3.2.1 (2019-08-12)
 
 1. Support actors
-    * [Pull request 101](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/101)
+    * [BitBucket pull request 101](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/101)
 
 ### Ignition Fuel Tools 3.2.0 (2019-06-14)
 
 1. FuelClient::DownloadModel accepts HTTP headers, and the `ign fuel
    download` command can accept a single HTTP header.
-    * [Pull request 100](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/100)
+    * [BitBucket pull request 100](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/100)
 
 ### Ignition Fuel Tools 3.1.0 (2019-05-xx)
 
 1. Fix PBR material URI
-    * [Pull request 95](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/95)
-    * [Pull request 96](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/96)
+    * [BitBucket pull request 95](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/95)
+    * [BitBucket pull request 96](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/96)
 
 ### Ignition Fuel Tools 3.0.0 (2018-02-28)
 
@@ -65,80 +65,80 @@
    fuel-tools to use ign-cmake2, sets api.ignitionfuel.org as the default
    server, fixes codecheck errors, removes old deprecations, and parses
    model.config files using tinyxml2.
-    * [Pull request 82](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/82)
-    * [Pull request 83](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/83)
-    * [Pull request 84](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/84)
-    * [Pull request 85](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/85)
-    * [Pull request 87](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/87)
-    * [Pull request 88](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/88)
-    * [Pull request 89](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/89)
+    * [BitBucket pull request 82](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/82)
+    * [BitBucket pull request 83](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/83)
+    * [BitBucket pull request 84](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/84)
+    * [BitBucket pull request 85](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/85)
+    * [BitBucket pull request 87](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/87)
+    * [BitBucket pull request 88](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/88)
+    * [BitBucket pull request 89](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/89)
 
 ## Ignition Fuel Tools 1.x
 
 ### Ignition Fuel Tools 1.x.x (20xx-xx-xx)
 
 1. Use `${YAML_TARGET}` instead of `YAML::YAML` imported target.
-    * [Pull request 103](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/103)
+    * [BitBucket pull request 103](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/103)
 
 ### Ignition Fuel Tools 1.2.0 (2018-05-30)
 
 1. Get cached model resource file
-    * [Pull request 63](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/63)
+    * [BitBucket pull request 63](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/63)
 
 1. Add some AsString functions
-    * [Pull request 54](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/54)
+    * [BitBucket pull request 54](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/54)
 
 1. Change cache directory structure and use it
-    * [Pull request 57](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/57)
-    * [Pull request 71](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/71)
-    * [Pull request 73](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/73)
+    * [BitBucket pull request 57](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/57)
+    * [BitBucket pull request 71](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/71)
+    * [BitBucket pull request 73](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/73)
 
 1. Client return only relevant cached models
-    * [Pull request 62](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/62)
+    * [BitBucket pull request 62](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/62)
 
 1. Model version support
-    * [Pull request 65](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/65)
+    * [BitBucket pull request 65](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/65)
 
 1. Remove server API version from model unique name
-    * [Pull request 47](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/47)
+    * [BitBucket pull request 47](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/47)
 
 1. Client handle unique names and get server info from config
-    * [Pull request 55](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/55)
+    * [BitBucket pull request 55](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/55)
 
 1. Changed model list to use headers for paging instead of iterating until
    a 404 is hit. Also added a mechanism to set the user agent
-    * [Pull request 46](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/46)
-    * [Pull request 61](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/61)
+    * [BitBucket pull request 46](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/46)
+    * [BitBucket pull request 61](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/61)
 
 1. FuelClient: Don't use ServerConfig if there's ModelId
-    * [Pull request 56](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/56)
+    * [BitBucket pull request 56](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/56)
 
 1. List models from command line
-    * [Pull request 43](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/43)
-    * [Pull request 48](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/48)
-    * [Pull request 44](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/44)
-    * [Pull request 45](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/45)
+    * [BitBucket pull request 43](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/43)
+    * [BitBucket pull request 48](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/48)
+    * [BitBucket pull request 44](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/44)
+    * [BitBucket pull request 45](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/45)
 
 1. Get cached model resource file
-    * [Pull request 63](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/63)
+    * [BitBucket pull request 63](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/63)
 
 1. Added const constructors for ModelIter and Model
-    * [Pull request 42](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/42)
+    * [BitBucket pull request 42](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/42)
 
 1. Use common::URI for server URL
-    * [Pull request 59](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/59)
+    * [BitBucket pull request 59](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/59)
 
 1. Remove server local name
-    * [Pull request 58](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/58)
+    * [BitBucket pull request 58](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/58)
 
 1. Encode url path before downloading models
-    * [Pull request 41](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/41)
+    * [BitBucket pull request 41](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/41)
 
 1. Download model from command line
-    * [Pull request 68](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/68)
+    * [BitBucket pull request 68](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/68)
 
 1. Backport code style changes
-    * [Pull request 69](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/69)
-    * [Pull request 67](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/67)
+    * [BitBucket pull request 69](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/69)
+    * [BitBucket pull request 67](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/67)
 
 ### Ignition Fuel Tools 1.0.0 (2018-01-25)

--- a/INSTALL_WINDOWS.md
+++ b/INSTALL_WINDOWS.md
@@ -27,7 +27,7 @@ need to [disable the Windows firewall](http://windows.microsoft.com/en-us/window
 
 1. Clone Ignition Fuel-Tools:
 
-        hg clone https://bitbucket.org/ignitionrobotics/ign-fuel-tools
+        git clone https://github.com/ignitionrobotics/ign-fuel-tools
         cd ign-fuel-tools
         mkdir build
 

--- a/Migration.md
+++ b/Migration.md
@@ -10,37 +10,37 @@
 ### Modifications
 
 1. Renamed the REST class to Rest.
-    * [Pull request #53](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-request/53)
+    * [BitBucket pull request #53](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/53)
 
 1. All setters (functions that set class variables) have been prefixed
    with `Set` and existing functions deprecated. Acronyms within class and
    function names have been changed from all-caps (e.g URL) to camel-case
    (eg. Url).
-    * [Pull request #49](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-request/49)
-    * [Pull request #51](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-request/51)
-    * [Pull request #52](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-request/52)
+    * [BitBucket pull request #49](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/49)
+    * [BitBucket pull request #51](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/51)
+    * [BitBucket pull request #52](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/52)
 
 1. Deprecated `env` function. Please use `igition::common::env`.
-    * [Pull request #50](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-request/50)
+    * [BitBucket pull request #50](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/50)
 
 1. Deprecated the `ModelIdentifier::Category` functions. The Category concept does not exist on fuelserver.
-    * [Pull request #52](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-request/52)
+    * [BitBucket pull request #52](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/52)
 
 1. Deprecated the accessor `ModelIdentifier::Likes` for `ModelIdentifier::LikeCount`, and the mutator `ModelIdentifier::Likes` for `ModelIdentifier::SetLikeCount`.
-    * [Pull request #52](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-request/52)
+    * [BitBucket pull request #52](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/52)
 
 1. Deprecated the accessor `ModelIdentifier::Downloads` for `ModelIdentifier::DownloadCount`, and the mutator `ModelIdentifier::Downloads` for `ModelIdentifier::SetDownloadCount`.
-    * [Pull request #52](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-request/52)
+    * [BitBucket pull request #52](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/52)
 
 
 1. ResultTypes have moved from a plain `enum` inside the `Result` class to
    an `enum class ResultType` outside the `Result` class scope.
-    * [Pull request #51](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/51/update-result-style/diff#chg-include/ignition/fuel_tools/Result.hh)
+    * [BitBucket pull request #51](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/51/update-result-style/diff#chg-include/ignition/fuel_tools/Result.hh)
 
 1. `ResultType Result::Type() const` now returns an `enum class`
    instead of a plain `enum`. This should not affect you unless you have
    been mapping `ResultType` to an `int`.
-    * [Pull request #51](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/51/update-result-style/diff#chg-include/ignition/fuel_tools/Result.hh)
+    * [BitBucket pull request #51](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/51/update-result-style/diff#chg-include/ignition/fuel_tools/Result.hh)
 
 ## Ignition Fuel Tools 1.2 to 1.X
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Ignition Fuel Tools is composed by a client library and command line tools for
 interacting with Ignition Fuel servers.
 
-  [http://bitbucket.org/ignitionrobotics/ign-fuel-tools](http://bitbucket.org/ignitionrobotics/ign-fuel-tools)
+  [http://github.com/ignitionrobotics/ign-fuel-tools](http://github.com/ignitionrobotics/ign-fuel-tools)
 
 Test coverage reports are available at Codecov:
 
@@ -113,10 +113,6 @@ On ubuntu run
 sudo apt install ruby-ffi libzip-dev libcurl-dev libjsoncpp-dev
 ```
 
-## Continuous integration
-
-Please refer to the [Bitbucket Pipelines](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/addon/pipelines/home#!/).
-
 ## Roadmap
 
 * Create the notion of "asset repository" or similar. An asset repository abstracts an entity that can store assets. It can be local or remote. This is the interface for "asset repository":
@@ -191,5 +187,5 @@ ln -s /usr/local/share/ignition/transportlog7.yaml .
 export IGN_CONFIG_PATH=$HOME/.ignition/tools/configs
 ```
 
-This issue is tracked [here](https://bitbucket.org/ignitionrobotics/ign-tools/issues/8/too-strict-looking-for-config-paths).
+This issue is tracked [here](https://github.com/ignitionrobotics/ign-tools/issues/8).
 

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -13,14 +13,14 @@ pipelines:
           - apt update
           - apt -y install
             cmake pkg-config python cppcheck doxygen ruby-ronn
-            mercurial libcurl4-openssl-dev libjsoncpp-dev libzip-dev libgflags-dev libtinyxml2-dev
+            git libcurl4-openssl-dev libjsoncpp-dev libzip-dev libgflags-dev libtinyxml2-dev
             lcov curl libyaml-dev
             libignition-cmake2-dev
             libignition-common3-dev
             libignition-math6-dev
             libignition-msgs5-dev
           # Ignition tools
-          - hg clone http://bitbucket.org/ignitionrobotics/ign-tools -b default
+          - git clone http://github.com/ignitionrobotics/ign-tools -b master
           - cd ign-tools
           - mkdir build
           - cd build
@@ -30,7 +30,7 @@ pipelines:
           # # Ignition msgs
           # - apt-get -y install
           #   libprotobuf-dev protobuf-compiler libprotoc-dev libtinyxml2-dev
-          # - hg clone http://bitbucket.org/ignitionrobotics/ign-msgs -b default
+          # - git clone http://github.com/ignitionrobotics/ign-msgs -b master
           # - cd ign-msgs
           # - mkdir build
           # - cd build

--- a/configure.bat
+++ b/configure.bat
@@ -8,8 +8,9 @@ call %win_lib% :download_unzip_install curl-7.57.0-vc15-x64-dll-MD.zip
 call %win_lib% :download_unzip_install jsoncpp-1.8.4-vc15-x64-dll-MD.zip
 call %win_lib% :download_unzip_install libyaml-0.1.7-vc15-x64-md.zip
 call %win_lib% :download_unzip_install libzip-1.4.0_zlip-1.2.11_vc15-x64-dll-MD.zip
+call %win_lib% :install_ign_project ign-tools ign-tools1
 call %win_lib% :install_ign_project ign-common ign-common3
-call %win_lib% :install_ign_project ign-msgs fuel_resource_metadata
+call %win_lib% :install_ign_project ign-msgs ign-msgs5
 
 :: Set configuration variables
 @set build_type=Release

--- a/doc/header.html
+++ b/doc/header.html
@@ -50,7 +50,7 @@
           <i class="mdl-color-text--grey-400 material-icons"
              role="presentation">launch</i>Ignition Website</a>
         <a class="mdl-navigation__link" target="_blank"
-           href="https://bitbucket.org/ignitionrobotics/ign-fuel-tools/issues/new">
+           href="https://github.com/ignitionrobotics/ign-fuel-tools/issues/new">
           <i class="mdl-color-text--grey-400 material-icons"
              role="presentation">warning</i>Report Issues</a>
 

--- a/src/ModelIter.cc
+++ b/src/ModelIter.cc
@@ -173,7 +173,6 @@ IterRestIds::IterRestIds(const Rest &_rest, const ServerConfig &_config,
     // TODO(nkoenig): resp.statusCode should return != 200 when the page
     // requested does
     // not exist. When this happens we should stop without calling ParseModels()
-    // https://bitbucket.org/ignitionrobotics/ign-fuelserver/issues/7
     if (resp.data == "null\n" || resp.statusCode != 200)
       break;
 

--- a/src/Zip_TEST.cc
+++ b/src/Zip_TEST.cc
@@ -16,7 +16,7 @@
 */
 
 // All these helper functions have been copied from
-// https://bitbucket.org/ignitionrobotics/ign-common/raw/default/src/Filesystem_TEST.cc
+// https://github.com/ignitionrobotics/ign-common/raw/master/src/Filesystem_TEST.cc
 
 #ifndef _WIN32
 #include <fcntl.h>

--- a/tutorials/01_installation.md
+++ b/tutorials/01_installation.md
@@ -73,13 +73,13 @@ sudo apt-get remove libignition-fuel-tools4-dev
 Install prerequisites. A clean Ubuntu system will need:
 
 ```
-sudo apt-get install mercurial cmake pkg-config python ruby-ronn libignition-cmake2-dev libignition-common3-dev libignition-msgs5-dev libignition-tools-dev libzip-dev libjsoncpp-dev libcurl4-openssl-dev libyaml-dev
+sudo apt-get install git cmake pkg-config python ruby-ronn libignition-cmake2-dev libignition-common3-dev libignition-msgs5-dev libignition-tools-dev libzip-dev libjsoncpp-dev libcurl4-openssl-dev libyaml-dev
 ```
 
 Clone the repository into a directory and go into it:
 
 ```
-hg clone https://bitbucket.org/ignitionrobotics/ign-fuel-tools /tmp/ign-fuel-tools
+git clone https://github.com/ignitionrobotics/ign-fuel-tools /tmp/ign-fuel-tools
 cd /tmp/ign-fuel-tools
 ```
 

--- a/tutorials/02_configuration.md
+++ b/tutorials/02_configuration.md
@@ -62,13 +62,13 @@ mkdir /tmp/conf_tutorial && cd /tmp/conf_tutorial
 Download the file `download.cc` and save it under `/tmp/conf_tutorial`:
 
 ```
-wget https://bitbucket.org/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools4/example/download.cc
+wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools4/example/download.cc
 ```
 
 Also, download `CMakeLists.txt` for compiling the example:
 
 ```
-wget https://bitbucket.org/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools4/example/CMakeLists.txt
+wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools4/example/CMakeLists.txt
 ```
 
 Install a dependency:

--- a/tutorials/04_cpp_api.md
+++ b/tutorials/04_cpp_api.md
@@ -17,10 +17,10 @@ Download the files `list.cc`, `details.cc`, `download.cc`,
 `CMakeLists.txt`, and save them under `/tmp/fuel_tutorial`:
 
 ```
-wget https://bitbucket.org/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools4/example/list.cc
-wget https://bitbucket.org/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools4/example/details.cc
-wget https://bitbucket.org/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools4/example/download.cc
-wget https://bitbucket.org/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools4/example/CMakeLists.txt
+wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools4/example/list.cc
+wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools4/example/details.cc
+wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools4/example/download.cc
+wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools4/example/CMakeLists.txt
 ```
 
 Let's start by compiling the examples:


### PR DESCRIPTION
I had forgot about this branch when updating links.

:farmer:  Also included some changes to try and fix the Windows CI:

https://build.osrfoundation.org/job/ignition_fuel-tools-ci-ign-fuel-tools4-windows7-amd64/