### PR TITLE
Fix URL path encoding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-fuel_tools3 VERSION 3.2.1)
+project(ignition-fuel_tools3 VERSION 3.2.2)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 ## Ignition Fuel Tools 3.x
 
-### Ignition Fuel Tools 3.2.1 (2020-05-xx)
+### Ignition Fuel Tools 3.2.2 (2020-05-18)
 
 1. Fix URL encodings in RestClient.
     * [Pull request 70](https://github.com/ignitionrobotics/ign-fuel-tools/pull/70)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,9 @@
 ## Ignition Fuel Tools 3.x
 
-### Ignition Fuel Tools 3.x.x (20xx-xx-xx)
+### Ignition Fuel Tools 3.2.1 (2020-05-xx)
+
+1. Fix URL encodings in RestClient.
+    * [Pull request XX]()
 
 1. Print message when downloading a resource.
     * [BitBucket pull request 102](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/102)

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@
 ### Ignition Fuel Tools 3.2.1 (2020-05-xx)
 
 1. Fix URL encodings in RestClient.
-    * [Pull request XX]()
+    * [Pull request 70](https://github.com/ignitionrobotics/ign-fuel-tools/pull/70)
 
 1. Print message when downloading a resource.
     * [BitBucket pull request 102](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/102)
@@ -119,4 +119,3 @@
     * [BitBucket pull request 67](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-fuel-tools/pull-requests/67)
 
 ### Ignition Fuel Tools 1.0.0 (2018-01-25)
-

--- a/src/RestClient.cc
+++ b/src/RestClient.cc
@@ -113,7 +113,15 @@ RestResponse Rest::Request(HttpMethod _method,
   std::string url = RestJoinUrl(_url, _version);
 
   CURL *curl = curl_easy_init();
-  char *encodedPath = curl_easy_escape(curl, _path.c_str(), _path.size());
+
+  // First, unescape the _path since it might have %XX encodings. If this
+  // step is not performed, then curl_easy_escape will encode the %XX
+  // encodings resulting in an incorrect URL.
+  int decodedSize;
+  char *decodedPath = curl_easy_unescape(curl,
+      _path.c_str(), _path.size(), &decodedSize);
+
+  char *encodedPath = curl_easy_escape(curl, decodedPath, decodedSize);
   url = RestJoinUrl(url, encodedPath);
 
   // Process query strings.


### PR DESCRIPTION
The "Drag Me" feature on Fuel is broken for models with spaces in the name. The root problem is that we are encoding URLs that were already encoded.

This change first decodes a URL, replacing "%XX" characters with their ASCII equivalent. This allows encoding to proceed correctly.

We are preventing resources from containing percent signs in:
1. https://gitlab.com/ignitionrobotics/web/fuelserver/-/merge_requests/15
2. https://gitlab.com/ignitionrobotics/web/app/-/merge_requests/17

Signed-off-by: Nate Koenig <nate@openrobotics.org>