### PR TITLE
Fix REST client URL encoding bug

### DIFF
--- a/src/RestClient.cc
+++ b/src/RestClient.cc
@@ -142,7 +142,9 @@ RestResponse Rest::Request(HttpMethod _method,
   std::string url = RestJoinUrl(_url, _version);
 
   CURL *curl = curl_easy_init();
-  char *encodedPath = curl_easy_escape(curl, _path.c_str(), _path.size());
+  char *encodedPath = curl_easy_unescape(curl, _path.c_str(), _path.size(),
+    NULL);
+  encodedPath = curl_easy_escape(curl, encodedPath, strlen(encodedPath));
   url = RestJoinUrl(url, encodedPath);
 
   // Process query strings.


### PR DESCRIPTION
When dragging in links to models into an Ignition Gazebo window, the `RestClient` gets called by `FuelClient` to parse the URL and post a `GET` Request.

Unfortunately, the way that it is parsed causes unexpected processing which breaks the url.

## Setup
I am on Ignition Citadel, and Ign Fuel is on 4.1.0

Recreate by dragging in URLs into Ignition Gazebo. Though this should work in the C++ API as well for `FuelClient` since Ignition Gazebo eventually calls `FuelClient.cc` and `RestClient.cc`

## Example
Input URL:
`https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Some%20Model`

**Expected `encodedPath`**: `OpenRobotics/models/Some%20Model`
**Actual output**: `OpenRobotics/models/Some%2520Model`

The reason this happens is because the **"%"** symbol is erroneously encoded into **"%25"**.

This is further verified because Ignition happily crunches in an input URL of:
`https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Some Model`

Which heavily implies that it is a URL encoding error.

## The Fix
Simply unencode any characters first before re-encoding them. Most use cases of this should already be inputting properly URL encoded strings. And this does not break any cases where unencoded URL strings are input.

## Extra Notes
I am not aware of any side-effects this might cause for other uses of the REST client.

As such I am pushing to master. If I should be pushing it to a different branch instead, let me know, and I'll recreate the PR.

## Relevant Screenshots
Failed URL fetch:
![image](https://user-images.githubusercontent.com/20265670/82297614-7c49e700-99e5-11ea-856a-f4f2ce424071.png)

But it clearly works!
![image](https://user-images.githubusercontent.com/20265670/82297711-a26f8700-99e5-11ea-85d3-7c80a3069cdf.png)

But dragging in `https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Pavement Plane` works! (Note the un-encoded whitespace.)
![image](https://user-images.githubusercontent.com/20265670/82297816-c763fa00-99e5-11ea-9d6e-4af340401e9a.png)

CH3EERS!
