### PR TITLE
Fix test worlds

### DIFF
--- a/src/FuelClient_TEST.cc
+++ b/src/FuelClient_TEST.cc
@@ -962,13 +962,13 @@ TEST_F(FuelClientTest, DownloadWorld)
     // Check it was downloaded to `1`
     EXPECT_EQ(path, common::cwd() +
         "/test_cache/fuel.ignitionrobotics.org/OpenRobotics/worlds/"
-        "Test world/1");
+        "Test world/2");
     EXPECT_TRUE(common::exists(
         "test_cache/fuel.ignitionrobotics.org/OpenRobotics/worlds/"
-        "Test world/1"));
+        "Test world/2"));
     EXPECT_TRUE(common::exists(
        "test_cache/fuel.ignitionrobotics.org/OpenRobotics/worlds/"
-       "Test world/1/test.world"));
+       "Test world/2/test.world"));
 
     // Check it wasn't downloaded to world root directory
     EXPECT_FALSE(common::exists(
@@ -980,7 +980,7 @@ TEST_F(FuelClientTest, DownloadWorld)
     EXPECT_TRUE(res3);
     EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res3);
     EXPECT_EQ(common::cwd() + "/test_cache/fuel.ignitionrobotics.org"
-      "/OpenRobotics/worlds/Test world/1", cachedPath);
+      "/OpenRobotics/worlds/Test world/2", cachedPath);
   }
 
   // Try using nonexistent URL

--- a/src/Interface_TEST.cc
+++ b/src/Interface_TEST.cc
@@ -178,11 +178,11 @@ TEST(Interface, FetchResources)
 
     // Check it was downloaded to `1`
     EXPECT_EQ(path, common::cwd() + "/test_cache/fuel.ignitionrobotics.org/"
-        "openrobotics/worlds/Test world/1");
+        "openrobotics/worlds/Test world/2");
     EXPECT_TRUE(common::exists("test_cache/fuel.ignitionrobotics.org/"
-        "openrobotics/worlds/Test world/1"));
+        "openrobotics/worlds/Test world/2"));
     EXPECT_TRUE(common::exists("test_cache/fuel.ignitionrobotics.org/"
-        "openrobotics/worlds/Test world/1/test.world"));
+        "openrobotics/worlds/Test world/2/test.world"));
 
     // Check it is cached
     {
@@ -191,7 +191,7 @@ TEST(Interface, FetchResources)
       EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res);
       EXPECT_EQ(common::cwd() +
           "/test_cache/fuel.ignitionrobotics.org/openrobotics/worlds/"
-          "Test world/1", cachedPath);
+          "Test world/2", cachedPath);
      }
   }
 
@@ -199,9 +199,9 @@ TEST(Interface, FetchResources)
   {
     // Check neither file nor its world are cached
     common::URI worldUrl{
-      "https://fuel.ignitionrobotics.org/1.0/chapulina/worlds/Test world/1/"};
+      "https://fuel.ignitionrobotics.org/1.0/chapulina/worlds/Test world/2/"};
     common::URI worldFileUrl{
-      "https://fuel.ignitionrobotics.org/1.0/chapulina/worlds/Test world/1/"
+      "https://fuel.ignitionrobotics.org/1.0/chapulina/worlds/Test world/2/"
       "files/thumbnails/1.png"};
 
     {
@@ -220,12 +220,12 @@ TEST(Interface, FetchResources)
 
     // Check entire world was downloaded to `1`
     EXPECT_TRUE(common::exists(
-        "test_cache/fuel.ignitionrobotics.org/chapulina/worlds/Test world/1"));
+        "test_cache/fuel.ignitionrobotics.org/chapulina/worlds/Test world/2"));
     EXPECT_EQ(path, common::cwd() +
-        "/test_cache/fuel.ignitionrobotics.org/chapulina/worlds/Test world/1/"
+        "/test_cache/fuel.ignitionrobotics.org/chapulina/worlds/Test world/2/"
         "thumbnails/1.png");
     EXPECT_TRUE(common::exists(
-        "test_cache/fuel.ignitionrobotics.org/chapulina/worlds/Test world/1/"
+        "test_cache/fuel.ignitionrobotics.org/chapulina/worlds/Test world/2/"
         "test.world"));
 
     // Check world is cached
@@ -234,7 +234,7 @@ TEST(Interface, FetchResources)
       EXPECT_TRUE(res);
       EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res);
       EXPECT_EQ(common::cwd() +
-          "/test_cache/fuel.ignitionrobotics.org/chapulina/worlds/Test world/1",
+          "/test_cache/fuel.ignitionrobotics.org/chapulina/worlds/Test world/2",
           cachedPath);
      }
 
@@ -244,7 +244,7 @@ TEST(Interface, FetchResources)
       EXPECT_TRUE(res);
       EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res);
       EXPECT_EQ(common::cwd() +
-          "/test_cache/fuel.ignitionrobotics.org/chapulina/worlds/Test world/1"
+          "/test_cache/fuel.ignitionrobotics.org/chapulina/worlds/Test world/2"
           "/thumbnails/1.png",
           cachedPath);
      }

--- a/src/ign_src_TEST.cc
+++ b/src/ign_src_TEST.cc
@@ -428,10 +428,10 @@ TEST(CmdLine, WorldDownloadUnversioned)
   EXPECT_TRUE(ignition::common::isDirectory(
       "test_cache/fuel.ignitionrobotics.org/OpenRobotics/worlds/Test world"));
   EXPECT_TRUE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/OpenRobotics/worlds/Test world/1"));
+      "test_cache/fuel.ignitionrobotics.org/OpenRobotics/worlds/Test world/2"));
   EXPECT_TRUE(ignition::common::isFile(
       std::string("test_cache/fuel.ignitionrobotics.org/OpenRobotics/worlds/")
-      + "Test world/1/test.world"));
+      + "Test world/2/test.world"));
 
   clearIOStreams(stdOutBuffer, stdErrBuffer);
   restoreIO();


### PR DESCRIPTION
I uploaded new versions of the test worlds so that they now have both `.world` (deprecated) and `.sdf` files. And having a new world version made a bunch of tests fail.

It's unfortunate that the tests need to be updated whenever the worlds are changed, but the hope is that this isn't something we'll do very often :crossed_fingers: 