### PR TITLE
Removed repeated installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,7 @@ Test coverage reports are available at Codecov:
 
 # Building and installing
 
-```
-cd ign-fuel-tools
-mkdir build
-cd build
-cmake ..
-make
-make test
-make install
-```
-
-Make sure `IGN_CONFIG_PATH` is set to the right install location`ign fuel` will work.
-Default is `/usr/local/share/ignition`.
+Review the [tutorial section](tutorials/01_installation.md).
 
 ## Examples
 
@@ -191,4 +180,3 @@ export IGN_CONFIG_PATH=$HOME/.ignition/tools/configs
 ```
 
 This issue is tracked [here](https://github.com/ignitionrobotics/ign-tools/issues/8).
-

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Test coverage reports are available at Codecov:
 
 # Building and installing
 
-Review the [tutorial section](tutorials/01_installation.md).
+Review the [tutorial section](https://ignitionrobotics.org/api/fuel_tools/4.0/install.html).
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Test coverage reports are available at Codecov:
 
 # Building and installing
 
-Review the [tutorial section](https://ignitionrobotics.org/api/fuel_tools/4.0/install.html).
+See the [installation tutorial](https://ignitionrobotics.org/api/fuel_tools/4.0/install.html).
 
 ## Examples
 

--- a/tutorials/01_installation.md
+++ b/tutorials/01_installation.md
@@ -92,24 +92,20 @@ cd build
 
 Configure Ignition Fuel Tools (choose either method a or b below):
 
-* A.  Release mode: This will generate optimized code, but will not have debug symbols. Use this mode if you don't need to use GDB.
+* **A**. Release mode: This will generate optimized code, but will not have debug symbols. Use this mode if you don't need to use GDB.
+```
+cmake ../
+```
+Note: You can use a custom install path to make it easier to switch
+between source and debian installs:
+```
+cmake -DCMAKE_INSTALL_PREFIX=/home/$USER/local ../
+```
 
-    ```
-    cmake ../
-    ```
-
-    Note: You can use a custom install path to make it easier to switch
-    between source and debian installs:
-
-    ```
-    cmake -DCMAKE_INSTALL_PREFIX=/home/$USER/local ../
-    ```
-
-* B. Debug mode: This will generate code with debug symbols. Ignition Fuel Tools will run slower, but you'll be able to use GDB.
-
-    ```
-    cmake -DCMAKE_BUILD_TYPE=Debug ../
-    ```
+* **B**. Debug mode: This will generate code with debug symbols. Ignition Fuel Tools will run slower, but you'll be able to use GDB.
+```
+cmake -DCMAKE_BUILD_TYPE=Debug ../
+```
 
 The output from `cmake ../` may generate a number of errors and warnings
 about missing packages. You must install the missing packages that have


### PR DESCRIPTION
This PR is related with this issue https://github.com/ignitionrobotics/docs/issues/14

Moved install instructions to the tutorials folder.

Signed-off-by: ahcorde <ahcorde@gmail.com>