### PR TITLE
👩‍🌾 Fix Windows build

### DIFF
--- a/include/ignition/fuel_tools/Result.hh
+++ b/include/ignition/fuel_tools/Result.hh
@@ -82,12 +82,21 @@ namespace ignition
       public: explicit Result(const ResultType _type);
 
       /// \brief Copy constructor.
-      /// \param[in] _orig Result to copy.
-      public: Result(const Result &_orig);
+      /// \param[in] _result Result to copy.
+      public: Result(const Result &_result);
+
+      /// \brief Move constructor
+      /// \param[in] _result Result to move.
+      public: Result(Result &&_result) noexcept;
 
       /// \brief Copy assignment operator.
-      /// \param[in] _orig Result to copy.
-      public: Result &operator=(const Result &_orig);
+      /// \param[in] _result Result to copy.
+      public: Result &operator=(const Result &_result);
+
+      /// \brief Move assignment operator.
+      /// \param[in] _result Result component to move.
+      /// \return Reference to this.
+      public: Result &operator=(Result &&_result) noexcept;
 
       /// \brief Get the type of result
       /// \return The type of result.

--- a/include/ignition/fuel_tools/Result.hh
+++ b/include/ignition/fuel_tools/Result.hh
@@ -85,6 +85,10 @@ namespace ignition
       /// \param[in] _orig Result to copy.
       public: Result(const Result &_orig);
 
+      /// \brief Copy assignment operator.
+      /// \param[in] _orig Result to copy.
+      public: Result &operator=(const Result &_orig);
+
       /// \brief Get the type of result
       /// \return The type of result.
       public: ResultType Type() const;

--- a/include/ignition/fuel_tools/Result.hh
+++ b/include/ignition/fuel_tools/Result.hh
@@ -74,6 +74,9 @@ namespace ignition
     /// \brief Class describing a result of an operation.
     class IGNITION_FUEL_TOOLS_VISIBLE Result
     {
+      /// \brief Default constructor, deleted
+      public: Result() = delete;
+
       /// \brief Destructor.
       public: ~Result();
 

--- a/include/ignition/fuel_tools/Result.hh
+++ b/include/ignition/fuel_tools/Result.hh
@@ -90,7 +90,7 @@ namespace ignition
 
       /// \brief Move constructor
       /// \param[in] _result Result to move.
-      public: Result(Result &&_result) noexcept;
+      public: Result(Result &&_result) noexcept;  // NOLINT
 
       /// \brief Copy assignment operator.
       /// \param[in] _result Result to copy.
@@ -99,7 +99,7 @@ namespace ignition
       /// \brief Move assignment operator.
       /// \param[in] _result Result component to move.
       /// \return Reference to this.
-      public: Result &operator=(Result &&_result) noexcept;
+      public: Result &operator=(Result &&_result) noexcept;  // NOLINT
 
       /// \brief Get the type of result
       /// \return The type of result.

--- a/include/ignition/fuel_tools/Result.hh
+++ b/include/ignition/fuel_tools/Result.hh
@@ -74,8 +74,8 @@ namespace ignition
     /// \brief Class describing a result of an operation.
     class IGNITION_FUEL_TOOLS_VISIBLE Result
     {
-      /// \brief Default constructor, deleted
-      public: Result() = delete;
+      /// \brief Default constructor
+      public: Result();
 
       /// \brief Destructor.
       public: ~Result();

--- a/src/CollectionIdentifier_TEST.cc
+++ b/src/CollectionIdentifier_TEST.cc
@@ -164,3 +164,10 @@ TEST(CollectionIdentifier, AsPrettyString)
     EXPECT_NE(str.find("raspberry"), std::string::npos);
   }
 }
+
+//////////////////////////////////////////////////
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/Result.cc
+++ b/src/Result.cc
@@ -30,9 +30,7 @@ class ignft::ResultPrivate
 
 
 //////////////////////////////////////////////////
-Result::~Result()
-{
-}
+Result::~Result() = default;
 
 //////////////////////////////////////////////////
 ResultType Result::Type() const
@@ -41,23 +39,30 @@ ResultType Result::Type() const
 }
 
 //////////////////////////////////////////////////
-Result::Result(const ResultType _type) : dataPtr(new ResultPrivate)
+Result::Result(const ResultType _type)
+  : dataPtr(std::make_unique<ResultPrivate>())
 {
   this->dataPtr->type = _type;
 }
 
 //////////////////////////////////////////////////
-Result::Result(const Result &_orig)
-  : dataPtr(std::make_unique<ResultPrivate>(*_orig.dataPtr))
+Result::Result(const Result &_result)
+  : dataPtr(std::make_unique<ResultPrivate>(*_result.dataPtr))
 {
 }
 
 /////////////////////////////////////////////////
-Result &Result::operator=(const Result &_orig)
+Result::Result(Result &&_result) noexcept = default;
+
+/////////////////////////////////////////////////
+Result &Result::operator=(const Result &_result)
 {
-  *this->dataPtr = (*_orig.dataPtr);
+  *this->dataPtr = (*_result.dataPtr);
   return *this;
 }
+
+/////////////////////////////////////////////////
+Result &Result::operator=(Result &&_result) noexcept = default;
 
 //////////////////////////////////////////////////
 Result::operator bool() const

--- a/src/Result.cc
+++ b/src/Result.cc
@@ -57,7 +57,7 @@ Result::Result(const Result &_result)
 }
 
 /////////////////////////////////////////////////
-Result::Result(Result &&_result) noexcept = default;
+Result::Result(Result &&_result) noexcept = default;  // NOLINT
 
 /////////////////////////////////////////////////
 Result &Result::operator=(const Result &_result)
@@ -67,7 +67,7 @@ Result &Result::operator=(const Result &_result)
 }
 
 /////////////////////////////////////////////////
-Result &Result::operator=(Result &&_result) noexcept = default;
+Result &Result::operator=(Result &&_result) noexcept = default;  // NOLINT
 
 //////////////////////////////////////////////////
 Result::operator bool() const

--- a/src/Result.cc
+++ b/src/Result.cc
@@ -47,9 +47,16 @@ Result::Result(const ResultType _type) : dataPtr(new ResultPrivate)
 }
 
 //////////////////////////////////////////////////
-Result::Result(const Result &_orig) : dataPtr(new ResultPrivate)
+Result::Result(const Result &_orig)
+  : dataPtr(std::make_unique<ResultPrivate>(*_orig.dataPtr))
 {
-  *(this->dataPtr) = *(_orig.dataPtr);
+}
+
+/////////////////////////////////////////////////
+Result &Result::operator=(const Result &_orig)
+{
+  *this->dataPtr = (*_orig.dataPtr);
+  return *this;
 }
 
 //////////////////////////////////////////////////

--- a/src/Result.cc
+++ b/src/Result.cc
@@ -28,6 +28,11 @@ class ignft::ResultPrivate
   public: ResultType type = ResultType::UNKNOWN;
 };
 
+//////////////////////////////////////////////////
+Result::Result()
+  : dataPtr(std::make_unique<ResultPrivate>())
+{
+}
 
 //////////////////////////////////////////////////
 Result::~Result() = default;

--- a/src/Result_TEST.cc
+++ b/src/Result_TEST.cc
@@ -41,6 +41,25 @@ TEST(Result, CopyAssignmentOperator)
 }
 
 /////////////////////////////////////////////////
+TEST(ResultTest, MoveConstructor)
+{
+  Result result(ResultType::UPLOAD);
+
+  Result resultMoved(std::move(result));
+  EXPECT_EQ(ResultType::UPLOAD, resultMoved.Type());
+}
+
+/////////////////////////////////////////////////
+TEST(ResultTest, MoveAssignmentOperator)
+{
+  Result result(ResultType::UPLOAD);
+
+  Result resultMoved(ResultType::DELETE);
+  resultMoved = std::move(result);
+  EXPECT_EQ(ResultType::UPLOAD, resultMoved.Type());
+}
+
+/////////////////////////////////////////////////
 /// \brief Create a request object with a type and check that it
 TEST(Result, TypeCanBeSet)
 {

--- a/src/Result_TEST.cc
+++ b/src/Result_TEST.cc
@@ -18,9 +18,27 @@
 #include <gtest/gtest.h>
 #include "ignition/fuel_tools/Result.hh"
 
-namespace ignft = ignition::fuel_tools;
 using namespace ignition;
-using namespace ignft;
+using namespace fuel_tools;
+
+/////////////////////////////////////////////////
+TEST(Result, CopyConstructor)
+{
+  Result result(ResultType::UPLOAD);
+
+  Result result2(result);
+  EXPECT_EQ(ResultType::UPLOAD, result2.Type());
+}
+
+/////////////////////////////////////////////////
+TEST(Result, CopyAssignmentOperator)
+{
+  Result result(ResultType::UPLOAD);
+
+  Result result2(ResultType::DELETE);
+  result2 = result;
+  EXPECT_EQ(ResultType::UPLOAD, result2.Type());
+}
 
 /////////////////////////////////////////////////
 /// \brief Create a request object with a type and check that it

--- a/src/Result_TEST.cc
+++ b/src/Result_TEST.cc
@@ -22,6 +22,13 @@ using namespace ignition;
 using namespace fuel_tools;
 
 /////////////////////////////////////////////////
+TEST(Result, DefaultConstructor)
+{
+  Result result;
+  EXPECT_EQ(ResultType::UNKNOWN, result.Type());
+}
+
+/////////////////////////////////////////////////
 TEST(Result, CopyConstructor)
 {
   Result result(ResultType::UPLOAD);
@@ -35,7 +42,7 @@ TEST(Result, CopyAssignmentOperator)
 {
   Result result(ResultType::UPLOAD);
 
-  Result result2(ResultType::DELETE);
+  Result result2;
   result2 = result;
   EXPECT_EQ(ResultType::UPLOAD, result2.Type());
 }


### PR DESCRIPTION
The Windows build was broken on #98.

The problem was using a class that doesn't have a default constructor inside a future:

https://github.com/ignitionrobotics/ign-fuel-tools/blob/2eb0ee784c0c795289dd34e64ff2b814f9cc64c8/src/ign.cc#L611

I tried a few different things but ended up just giving the class a default constructor, which I don't think is unreasonable.