### PR TITLE
Missing download j option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-fuel_tools4 VERSION 4.2.0)
+project(ignition-fuel_tools4 VERSION 4.2.1)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 ## Ignition Fuel Tools 4.x
 
+### Ignition Fuel Tools 4.2.1 (2020-08-26)
+
+1. Fix `ign fuel download`, which was missing the `-j` option.
+    * [Pull request 116](https://github.com/ignitionrobotics/ign-fuel-tools/pull/116)
+
 ### Ignition Fuel Tools 4.2.0 (2020-08-26)
 
 1. Set license information based on licenses available from a Fuel server

--- a/src/cmd/cmdfuel.rb.in
+++ b/src/cmd/cmdfuel.rb.in
@@ -148,11 +148,7 @@ SUBCOMMANDS = {
   "  -p [--private]           Use this argument to make the model private. \n"\
   "                           Otherwise, the model will be public.         \n"\
   "  --header arg             Set an HTTP header, such as                  \n"\
-  "                           --header 'Private-Token: <access_token>'.    \n"\
-  "  -j [--jobs] arg          Number of parallel downloads (default: 1, max: #{MAX_PARALLEL_JOBS}). \n"\
-  "  -t [--type] arg          Limit what resource type (i.e. model, world) to download \n" \
-  "                           from a collection. All resources will be downloaded if\n" \
-  "                           unspecified. Ignored if not downloading collection. \n" +
+  "                           --header 'Private-Token: <access_token>'.    \n" +
   COMMON_OPTIONS,
 }
 

--- a/src/cmd/cmdfuel.rb.in
+++ b/src/cmd/cmdfuel.rb.in
@@ -83,7 +83,13 @@ SUBCOMMANDS = {
   "  -u [--url] arg           Full resource URL, such as:                  \n"\
   "                           https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Ambulance\n"\
   "  --header arg             Set an HTTP header, such as                  \n"\
-  "                           --header 'authorization: Bearer JWT'.        \n" +
+  "                           --header 'authorization: Bearer JWT'.        \n"\
+  "  -j [--jobs] arg          Number of parallel downloads (default: 1,    \n"\
+  "                           max: #{MAX_PARALLEL_JOBS}). \n"\
+  "  -t [--type] arg          Limit what resource type (i.e. model, world) \n"\
+  "                           to download from a collection. All resources \n"\
+  "                           will be downloaded if unspecified. Ignored   \n"\
+  "                           if not downloading collection.               \n"+
   COMMON_OPTIONS,
 
  'edit' =>


### PR DESCRIPTION
I missed [this error](https://github.com/ignitionrobotics/ign-fuel-tools/pull/102/files#diff-e2cbfe78be4b938d0d98f934858418dfL144) when merging forward.

The `-j and -t` options should be associated with `download`, not `upload`.