### PR TITLE
⬆️ Bump main to 6.0.0~pre1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-fuel_tools5 VERSION 5.0.0)
+project(ignition-fuel_tools6 VERSION 6.0.0)
 
 #============================================================================
 # Find ignition-cmake

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 
 # Find the Ignition Fuel Tools library
-find_package(ignition-fuel_tools5 QUIET REQUIRED)
+find_package(ignition-fuel_tools6 QUIET REQUIRED)
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${IGNITION-FUEL-TOOLS_CXX_FLAGS}")
 include_directories(
   ${IGNITION-COMMON_INCLUDE_DIRS}


### PR DESCRIPTION
The `ign-fuel-tools5` branch was created off main for the Dome release.

Now bumping main to version 6 so it may receive breaking changes.