### PR TITLE
Use lowercase resource and owner names when storing assets on disk

### DIFF
--- a/src/ClientConfig_TEST.cc
+++ b/src/ClientConfig_TEST.cc
@@ -52,7 +52,7 @@ std::string homePath()
 #ifndef _WIN32
   ignition::common::env("HOME", homePath);
 #else
-  ignition::common::env("HOMEPATH", homePath);
+  ignition::common::env("USERPROFILE", homePath);
 #endif
 
   return homePath;

--- a/src/CollectionIdentifier_TEST.cc
+++ b/src/CollectionIdentifier_TEST.cc
@@ -145,7 +145,7 @@ TEST(CollectionIdentifier, AsString)
     std::string str =
         "Name: \n"\
         "Owner: \n"\
-        "Unique name: https://fuel.ignitionrobotics.org\\\\collections\\\n"
+        "Unique name: https://fuel.ignitionrobotics.org\\collections\n"
         "Server:\n"
         "  URL: https://fuel.ignitionrobotics.org\n"
         "  Version: 1.0\n"

--- a/src/FuelClient_TEST.cc
+++ b/src/FuelClient_TEST.cc
@@ -147,7 +147,7 @@ TEST_F(FuelClientTest, ParseModelURL)
     EXPECT_EQ(id.Server().Url().Str(), "https://some.example.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "german");
-    EXPECT_EQ(id.Name(), "Cardboard Box");
+    EXPECT_EQ(id.Name(), "cardboard box");
     EXPECT_EQ(id.Version(), 0u);
   }
 
@@ -166,7 +166,7 @@ TEST_F(FuelClientTest, ParseModelURL)
     EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "german");
-    EXPECT_EQ(id.Name(), "Cardboard Box");
+    EXPECT_EQ(id.Name(), "cardboard box");
     EXPECT_EQ(id.Version(), 4u);
   }
 
@@ -185,7 +185,7 @@ TEST_F(FuelClientTest, ParseModelURL)
     EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "german");
-    EXPECT_EQ(id.Name(), "Cardboard Box");
+    EXPECT_EQ(id.Name(), "cardboard box");
     EXPECT_EQ(id.Version(), 6u);
   }
 
@@ -202,7 +202,7 @@ TEST_F(FuelClientTest, ParseModelURL)
     EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
     EXPECT_FALSE(id.Server().Version().empty());
     EXPECT_EQ(id.Owner(), "german");
-    EXPECT_EQ(id.Name(), "Cardboard Box");
+    EXPECT_EQ(id.Name(), "cardboard box");
     EXPECT_EQ(id.Version(), 0u);
   }
 
@@ -221,7 +221,7 @@ TEST_F(FuelClientTest, ParseModelURL)
     EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "german");
-    EXPECT_EQ(id.Name(), "Cardboard Box");
+    EXPECT_EQ(id.Name(), "cardboard box");
     EXPECT_EQ(id.Version(), 0u);
   }
 
@@ -292,8 +292,8 @@ TEST_F(FuelClientTest, ParseModelFileURL)
 
     EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
-    EXPECT_EQ(id.Owner(), "OpenRobotics");
-    EXPECT_EQ(id.Name(), "Cordless Drill");
+    EXPECT_EQ(id.Owner(), "openrobotics");
+    EXPECT_EQ(id.Name(), "cordless drill");
     EXPECT_EQ(filePath, "meshes/cordless_drill.dae");
   }
 
@@ -305,14 +305,14 @@ TEST_F(FuelClientTest, ParseModelFileURL)
     ModelIdentifier id;
     std::string filePath;
     const common::URI modelUrl{
-      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Pine Tree/tip/"
+      "https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Pine Tree/tip/"
       "files/materials/scripts/pine_tree.material"};
     EXPECT_TRUE(client.ParseModelFileUrl(modelUrl, id, filePath));
 
     EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
-    EXPECT_EQ(id.Owner(), "OpenRobotics");
-    EXPECT_EQ(id.Name(), "Pine Tree");
+    EXPECT_EQ(id.Owner(), "openrobotics");
+    EXPECT_EQ(id.Name(), "pine tree");
     EXPECT_EQ(filePath, "materials/scripts/pine_tree.material");
   }
 
@@ -330,8 +330,8 @@ TEST_F(FuelClientTest, ParseModelFileURL)
 
     EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
-    EXPECT_EQ(id.Owner(), "OpenRobotics");
-    EXPECT_EQ(id.Name(), "Pine Tree");
+    EXPECT_EQ(id.Owner(), "openrobotics");
+    EXPECT_EQ(id.Name(), "pine tree");
     EXPECT_EQ(filePath, "model.sdf");
   }
 
@@ -341,15 +341,15 @@ TEST_F(FuelClientTest, ParseModelFileURL)
     ModelIdentifier id;
     std::string filePath;
     const common::URI modelUrl{
-      "https://fuel.ignitionrobotics.org/OpenRobotics/models/Pine Tree/tip/"
+      "https://fuel.ignitionrobotics.org/OpenRobotics/models/pine tree/tip/"
       "files/materials/scripts/pine_tree.material"};
     EXPECT_TRUE(client.ParseModelFileUrl(modelUrl, id, filePath));
 
     EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
     EXPECT_FALSE(id.Server().Version().empty());
     EXPECT_EQ("1.0", id.Server().Version());
-    EXPECT_EQ(id.Owner(), "OpenRobotics");
-    EXPECT_EQ(id.Name(), "Pine Tree");
+    EXPECT_EQ(id.Owner(), "openrobotics");
+    EXPECT_EQ(id.Name(), "pine tree");
     EXPECT_EQ(filePath, "materials/scripts/pine_tree.material");
   }
 
@@ -361,14 +361,14 @@ TEST_F(FuelClientTest, ParseModelFileURL)
     ModelIdentifier id;
     std::string filePath;
     const common::URI modelUrl{
-      "https://fuel.ignitionrobotics.org/OpenRobotics/models/Pine Tree/tip/"
+      "https://fuel.ignitionrobotics.org/openrobotics/models/Pine Tree/tip/"
       "files/materials/scripts/pine_tree.material"};
     EXPECT_TRUE(client.ParseModelFileUrl(modelUrl, id, filePath));
 
     EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
-    EXPECT_EQ(id.Owner(), "OpenRobotics");
-    EXPECT_EQ(id.Name(), "Pine Tree");
+    EXPECT_EQ(id.Owner(), "openrobotics");
+    EXPECT_EQ(id.Name(), "pine tree");
     EXPECT_EQ(filePath, "materials/scripts/pine_tree.material");
   }
 
@@ -427,7 +427,7 @@ TEST_F(FuelClientTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(DownloadModel))
 
     // Check it was downloaded to `2`
     auto modelPath = common::joinPaths(common::cwd(), "test_cache",
-        "fuel.ignitionrobotics.org", "chapulina", "models", "Test box");
+        "fuel.ignitionrobotics.org", "chapulina", "models", "test box");
 
     EXPECT_EQ(path, common::joinPaths(modelPath, "2"));
     EXPECT_TRUE(common::exists(common::joinPaths(modelPath, "2")));
@@ -465,7 +465,7 @@ TEST_F(FuelClientTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(DownloadModel))
 
     // Check it was downloaded to `2`
     auto modelPath = common::joinPaths(common::cwd(), "test_cache",
-        "fuel.ignitionrobotics.org", "iche033", "models", "Rescue Randy");
+        "fuel.ignitionrobotics.org", "iche033", "models", "rescue randy");
 
     EXPECT_EQ(path, common::joinPaths(modelPath, "2"));
     EXPECT_TRUE(common::exists(common::joinPaths(modelPath, "2")));
@@ -668,7 +668,7 @@ TEST_F(FuelClientTest, ParseWorldUrl)
     EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "german");
-    EXPECT_EQ(id.Name(), "Cardboard Box");
+    EXPECT_EQ(id.Name(), "cardboard box");
     EXPECT_EQ(id.Version(), 0u);
   }
 
@@ -687,7 +687,7 @@ TEST_F(FuelClientTest, ParseWorldUrl)
     EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "german");
-    EXPECT_EQ(id.Name(), "Cardboard Box");
+    EXPECT_EQ(id.Name(), "cardboard box");
     EXPECT_EQ(id.Version(), 4u);
   }
 
@@ -706,7 +706,7 @@ TEST_F(FuelClientTest, ParseWorldUrl)
     EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "german");
-    EXPECT_EQ(id.Name(), "Cardboard Box");
+    EXPECT_EQ(id.Name(), "cardboard box");
     EXPECT_EQ(id.Version(), 6u);
   }
 
@@ -724,7 +724,7 @@ TEST_F(FuelClientTest, ParseWorldUrl)
     EXPECT_FALSE(id.Server().Version().empty());
     EXPECT_EQ("1.0", id.Server().Version());
     EXPECT_EQ(id.Owner(), "german");
-    EXPECT_EQ(id.Name(), "Cardboard Box");
+    EXPECT_EQ(id.Name(), "cardboard box");
     EXPECT_EQ(id.Version(), 0u);
   }
 
@@ -743,7 +743,7 @@ TEST_F(FuelClientTest, ParseWorldUrl)
     EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "german");
-    EXPECT_EQ(id.Name(), "Cardboard Box");
+    EXPECT_EQ(id.Name(), "cardboard box");
     EXPECT_EQ(id.Version(), 0u);
   }
 
@@ -811,8 +811,8 @@ TEST_F(FuelClientTest, ParseWorldFileUrl)
 
     EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
-    EXPECT_EQ(id.Owner(), "OpenRobotics");
-    EXPECT_EQ(id.Name(), "Empty");
+    EXPECT_EQ(id.Owner(), "openrobotics");
+    EXPECT_EQ(id.Name(), "empty");
     EXPECT_EQ(filePath, "test.world");
   }
 
@@ -830,8 +830,8 @@ TEST_F(FuelClientTest, ParseWorldFileUrl)
 
     EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
-    EXPECT_EQ(id.Owner(), "OpenRobotics");
-    EXPECT_EQ(id.Name(), "Empty sky");
+    EXPECT_EQ(id.Owner(), "openrobotics");
+    EXPECT_EQ(id.Name(), "empty sky");
     EXPECT_EQ(filePath, "empty_sky.world");
   }
 
@@ -849,8 +849,8 @@ TEST_F(FuelClientTest, ParseWorldFileUrl)
 
     EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
-    EXPECT_EQ(id.Owner(), "OpenRobotics");
-    EXPECT_EQ(id.Name(), "Empty");
+    EXPECT_EQ(id.Owner(), "openrobotics");
+    EXPECT_EQ(id.Name(), "empty");
     EXPECT_EQ(filePath, "test.world");
   }
 
@@ -867,8 +867,8 @@ TEST_F(FuelClientTest, ParseWorldFileUrl)
     EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
     EXPECT_FALSE(id.Server().Version().empty());
     EXPECT_EQ("1.0", id.Server().Version());
-    EXPECT_EQ(id.Owner(), "OpenRobotics");
-    EXPECT_EQ(id.Name(), "Empty sky");
+    EXPECT_EQ(id.Owner(), "openrobotics");
+    EXPECT_EQ(id.Name(), "empty sky");
     EXPECT_EQ(filePath, "empty_sky.world");
   }
 
@@ -886,8 +886,8 @@ TEST_F(FuelClientTest, ParseWorldFileUrl)
 
     EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
-    EXPECT_EQ(id.Owner(), "OpenRobotics");
-    EXPECT_EQ(id.Name(), "Empty");
+    EXPECT_EQ(id.Owner(), "openrobotics");
+    EXPECT_EQ(id.Name(), "empty");
     EXPECT_EQ(filePath, "test.world");
   }
 
@@ -952,7 +952,7 @@ TEST_F(FuelClientTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(DownloadWorld))
 
     // Check it was downloaded to `1`
     auto worldPath = common::joinPaths(common::cwd(), "test_cache",
-        "fuel.ignitionrobotics.org", "OpenRobotics", "worlds", "Test world");
+        "fuel.ignitionrobotics.org", "openrobotics", "worlds", "test world");
 
     EXPECT_EQ(path, common::joinPaths(worldPath, "2"));
     EXPECT_TRUE(common::exists(common::joinPaths(worldPath, "2")));

--- a/src/Interface_TEST.cc
+++ b/src/Interface_TEST.cc
@@ -72,14 +72,14 @@ TEST(Interface, IGN_UTILS_TEST_DISABLED_ON_WIN32(FetchResources))
 
     // Check it was downloaded to `2`
     EXPECT_EQ(path, common::cwd() +
-        "/test_cache/fuel.ignitionrobotics.org/chapulina/models/Test box/2");
+        "/test_cache/fuel.ignitionrobotics.org/chapulina/models/test box/2");
     EXPECT_TRUE(common::exists(
-        "test_cache/fuel.ignitionrobotics.org/chapulina/models/Test box/2"));
+        "test_cache/fuel.ignitionrobotics.org/chapulina/models/test box/2"));
     EXPECT_TRUE(common::exists(
-        "test_cache/fuel.ignitionrobotics.org/chapulina/models/Test box/2/"
+        "test_cache/fuel.ignitionrobotics.org/chapulina/models/test box/2/"
         "model.sdf"));
     EXPECT_TRUE(common::exists(
-        "test_cache/fuel.ignitionrobotics.org/chapulina/models/Test box/2/"
+        "test_cache/fuel.ignitionrobotics.org/chapulina/models/test box/2/"
         "model.config"));
 
     // Check it wasn't downloaded to model root directory
@@ -93,7 +93,7 @@ TEST(Interface, IGN_UTILS_TEST_DISABLED_ON_WIN32(FetchResources))
       EXPECT_TRUE(res);
       EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res);
       EXPECT_EQ(common::cwd() +
-          "/test_cache/fuel.ignitionrobotics.org/chapulina/models/Test box/2",
+          "/test_cache/fuel.ignitionrobotics.org/chapulina/models/test box/2",
           cachedPath);
      }
   }
@@ -123,24 +123,24 @@ TEST(Interface, IGN_UTILS_TEST_DISABLED_ON_WIN32(FetchResources))
 
     // Check entire model was downloaded to `1`
     EXPECT_TRUE(common::exists(
-        "test_cache/fuel.ignitionrobotics.org/openrobotics/models/Bus/1"));
+        "test_cache/fuel.ignitionrobotics.org/openrobotics/models/bus/1"));
     EXPECT_EQ(path, common::cwd() +
-        "/test_cache/fuel.ignitionrobotics.org/openrobotics/models/Bus/1/"
+        "/test_cache/fuel.ignitionrobotics.org/openrobotics/models/bus/1/"
         "meshes/bus.obj");
     EXPECT_TRUE(common::exists(
-        "test_cache/fuel.ignitionrobotics.org/openrobotics/models/Bus/1/"
+        "test_cache/fuel.ignitionrobotics.org/openrobotics/models/bus/1/"
         "model.sdf"));
     EXPECT_TRUE(common::exists(
-        "test_cache/fuel.ignitionrobotics.org/openrobotics/models/Bus/1/"
+        "test_cache/fuel.ignitionrobotics.org/openrobotics/models/bus/1/"
         "model.config"));
     EXPECT_TRUE(common::exists(
-        "test_cache/fuel.ignitionrobotics.org/openrobotics/models/Bus/1/"
+        "test_cache/fuel.ignitionrobotics.org/openrobotics/models/bus/1/"
         "meshes/bus.obj"));
     EXPECT_TRUE(common::exists(
-        "test_cache/fuel.ignitionrobotics.org/openrobotics/models/Bus/1/"
+        "test_cache/fuel.ignitionrobotics.org/openrobotics/models/bus/1/"
         "meshes/bus.mtl"));
     EXPECT_TRUE(common::exists(
-        "test_cache/fuel.ignitionrobotics.org/openrobotics/models/Bus/1/"
+        "test_cache/fuel.ignitionrobotics.org/openrobotics/models/bus/1/"
         "materials/textures/bus.png"));
 
     // Check model is cached
@@ -149,7 +149,7 @@ TEST(Interface, IGN_UTILS_TEST_DISABLED_ON_WIN32(FetchResources))
       EXPECT_TRUE(res);
       EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res);
       EXPECT_EQ(common::cwd() +
-          "/test_cache/fuel.ignitionrobotics.org/openrobotics/models/Bus/1",
+          "/test_cache/fuel.ignitionrobotics.org/openrobotics/models/bus/1",
           cachedPath);
      }
 
@@ -159,7 +159,7 @@ TEST(Interface, IGN_UTILS_TEST_DISABLED_ON_WIN32(FetchResources))
       EXPECT_TRUE(res);
       EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res);
       EXPECT_EQ(common::cwd() +
-          "/test_cache/fuel.ignitionrobotics.org/openrobotics/models/Bus/1"
+          "/test_cache/fuel.ignitionrobotics.org/openrobotics/models/bus/1"
           "/meshes/bus.obj",
           cachedPath);
      }
@@ -181,11 +181,11 @@ TEST(Interface, IGN_UTILS_TEST_DISABLED_ON_WIN32(FetchResources))
 
     // Check it was downloaded to `1`
     EXPECT_EQ(path, common::cwd() + "/test_cache/fuel.ignitionrobotics.org/"
-        "openrobotics/worlds/Test world/2");
+        "openrobotics/worlds/test world/2");
     EXPECT_TRUE(common::exists("test_cache/fuel.ignitionrobotics.org/"
-        "openrobotics/worlds/Test world/2"));
+        "openrobotics/worlds/test world/2"));
     EXPECT_TRUE(common::exists("test_cache/fuel.ignitionrobotics.org/"
-        "openrobotics/worlds/Test world/2/test.world"));
+        "openrobotics/worlds/test world/2/test.world"));
 
     // Check it is cached
     {
@@ -194,7 +194,7 @@ TEST(Interface, IGN_UTILS_TEST_DISABLED_ON_WIN32(FetchResources))
       EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res);
       EXPECT_EQ(common::cwd() +
           "/test_cache/fuel.ignitionrobotics.org/openrobotics/worlds/"
-          "Test world/2", cachedPath);
+          "test world/2", cachedPath);
      }
   }
 
@@ -223,12 +223,12 @@ TEST(Interface, IGN_UTILS_TEST_DISABLED_ON_WIN32(FetchResources))
 
     // Check entire world was downloaded to `1`
     EXPECT_TRUE(common::exists(
-        "test_cache/fuel.ignitionrobotics.org/chapulina/worlds/Test world/2"));
+        "test_cache/fuel.ignitionrobotics.org/chapulina/worlds/test world/2"));
     EXPECT_EQ(path, common::cwd() +
-        "/test_cache/fuel.ignitionrobotics.org/chapulina/worlds/Test world/2/"
+        "/test_cache/fuel.ignitionrobotics.org/chapulina/worlds/test world/2/"
         "thumbnails/1.png");
     EXPECT_TRUE(common::exists(
-        "test_cache/fuel.ignitionrobotics.org/chapulina/worlds/Test world/2/"
+        "test_cache/fuel.ignitionrobotics.org/chapulina/worlds/test world/2/"
         "test.world"));
 
     // Check world is cached
@@ -237,7 +237,7 @@ TEST(Interface, IGN_UTILS_TEST_DISABLED_ON_WIN32(FetchResources))
       EXPECT_TRUE(res);
       EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res);
       EXPECT_EQ(common::cwd() +
-          "/test_cache/fuel.ignitionrobotics.org/chapulina/worlds/Test world/2",
+          "/test_cache/fuel.ignitionrobotics.org/chapulina/worlds/test world/2",
           cachedPath);
      }
 
@@ -247,7 +247,7 @@ TEST(Interface, IGN_UTILS_TEST_DISABLED_ON_WIN32(FetchResources))
       EXPECT_TRUE(res);
       EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res);
       EXPECT_EQ(common::cwd() +
-          "/test_cache/fuel.ignitionrobotics.org/chapulina/worlds/Test world/2"
+          "/test_cache/fuel.ignitionrobotics.org/chapulina/worlds/test world/2"
           "/thumbnails/1.png",
           cachedPath);
      }

--- a/src/ModelIdentifier.cc
+++ b/src/ModelIdentifier.cc
@@ -21,6 +21,7 @@
 
 #include <ignition/common/Console.hh>
 #include <ignition/common/Filesystem.hh>
+#include <ignition/common/Util.hh>
 
 #include "ignition/fuel_tools/ClientConfig.hh"
 #include "ignition/fuel_tools/ModelIdentifier.hh"
@@ -154,22 +155,24 @@ std::string ModelIdentifier::Name() const
 bool ModelIdentifier::SetName(const std::string &_name)
 {
   bool success = false;
-  if (this->dataPtr->ValidName(_name))
+  std::string name = common::lowercase(_name);
+  if (this->dataPtr->ValidName(name))
   {
     success = true;
-    this->dataPtr->name = _name;
+    this->dataPtr->name = name;
   }
   return success;
 }
 
 //////////////////////////////////////////////////
-bool ModelIdentifier::SetOwner(const std::string &_name)
+bool ModelIdentifier::SetOwner(const std::string &_owner)
 {
   bool success = false;
-  if (this->dataPtr->ValidName(_name))
+  std::string owner = common::lowercase(_owner);
+  if (this->dataPtr->ValidName(owner))
   {
     success = true;
-    this->dataPtr->owner = _name;
+    this->dataPtr->owner = owner;
   }
   return success;
 }

--- a/src/ModelIdentifier_TEST.cc
+++ b/src/ModelIdentifier_TEST.cc
@@ -168,7 +168,7 @@ TEST(ModelIdentifier, AsString)
         "Name: \n"\
         "Owner: \n"\
         "Version: tip\n"\
-        "Unique name: https://fuel.ignitionrobotics.org\\\\models\\\n"
+        "Unique name: https://fuel.ignitionrobotics.org\\models\n"
         "Description: \n"
         "File size: 0\n"
         "Upload date: 0\n"

--- a/src/WorldIdentifier.cc
+++ b/src/WorldIdentifier.cc
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include <ignition/common/Filesystem.hh>
+#include <ignition/common/Util.hh>
 
 #include "ignition/fuel_tools/ClientConfig.hh"
 #include "ignition/fuel_tools/WorldIdentifier.hh"
@@ -93,7 +94,7 @@ std::string WorldIdentifier::Name() const
 //////////////////////////////////////////////////
 bool WorldIdentifier::SetName(const std::string &_name)
 {
-  this->dataPtr->name = _name;
+  this->dataPtr->name = common::lowercase(_name);
   return true;
 }
 
@@ -104,9 +105,9 @@ std::string WorldIdentifier::Owner() const
 }
 
 //////////////////////////////////////////////////
-bool WorldIdentifier::SetOwner(const std::string &_name)
+bool WorldIdentifier::SetOwner(const std::string &_owner)
 {
-  this->dataPtr->owner = _name;
+  this->dataPtr->owner = common::lowercase(_owner);
   return true;
 }
 

--- a/src/WorldIdentifier_TEST.cc
+++ b/src/WorldIdentifier_TEST.cc
@@ -131,7 +131,7 @@ TEST(WorldIdentifier, AsString)
         "Name: \n"\
         "Owner: \n"\
         "Version: tip\n"\
-        "Unique name: fuel.ignitionrobotics.org\\\\worlds\\\n"
+        "Unique name: fuel.ignitionrobotics.org\\worlds\n"
         "Local path: \n"
         "Server:\n"
         "  URL: https://fuel.ignitionrobotics.org\n"

--- a/src/ign_src_TEST.cc
+++ b/src/ign_src_TEST.cc
@@ -137,7 +137,7 @@ TEST(CmdLine, IGN_UTILS_TEST_DISABLED_ON_WIN32(
   redirectIO(stdOutBuffer, stdErrBuffer);
 
   EXPECT_TRUE(listModels("https://staging-fuel.ignitionrobotics.org",
-      "OpenRobotics"));
+      "openrobotics"));
 
   EXPECT_NE(stdOutBuffer.str().find(
         "https://staging-fuel.ignitionrobotics.org"),
@@ -222,12 +222,12 @@ TEST(CmdLine, IGN_UTILS_TEST_DISABLED_ON_WIN32(ModelDownloadUnversioned))
 
   // Check files
   EXPECT_TRUE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/chapulina/models/Test box"));
+      "test_cache/fuel.ignitionrobotics.org/chapulina/models/test box"));
   EXPECT_TRUE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/chapulina/models/Test box/2"));
+      "test_cache/fuel.ignitionrobotics.org/chapulina/models/test box/2"));
   EXPECT_TRUE(ignition::common::isFile(
       std::string("test_cache/fuel.ignitionrobotics.org/chapulina/models") +
-      "/Test box/2/model.sdf"));
+      "/test box/2/model.sdf"));
 
   clearIOStreams(stdOutBuffer, stdErrBuffer);
   restoreIO();
@@ -277,7 +277,7 @@ TEST(CmdLine, IGN_UTILS_TEST_DISABLED_ON_WIN32(DownloadConfigCache))
   // Check files
   auto modelPath = common::joinPaths(std::string(PROJECT_BINARY_PATH),
       "test_cache", "fuel.ignitionrobotics.org", "chapulina", "models",
-      "Test box");
+      "test box");
   EXPECT_TRUE(ignition::common::isDirectory(modelPath));
   EXPECT_TRUE(ignition::common::isDirectory(common::joinPaths(modelPath, "2")));
   EXPECT_TRUE(ignition::common::isFile(common::joinPaths(modelPath, "2",
@@ -365,7 +365,7 @@ TEST(CmdLine, WorldListCustomServerPrettyOwner)
   redirectIO(stdOutBuffer, stdErrBuffer);
 
   EXPECT_TRUE(listWorlds("https://staging-fuel.ignitionrobotics.org",
-      "OpenRobotics"));
+      "openrobotics"));
 
   EXPECT_NE(stdOutBuffer.str().find(
         "https://staging-fuel.ignitionrobotics.org"), std::string::npos)
@@ -452,12 +452,12 @@ TEST(FuelClientTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(
 
   // Check files
   EXPECT_TRUE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/OpenRobotics/worlds/Test world"));
+      "test_cache/fuel.ignitionrobotics.org/openrobotics/worlds/test world"));
   EXPECT_TRUE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/OpenRobotics/worlds/Test world/2"));
+      "test_cache/fuel.ignitionrobotics.org/openrobotics/worlds/test world/2"));
   EXPECT_TRUE(ignition::common::isFile(
-      std::string("test_cache/fuel.ignitionrobotics.org/OpenRobotics/worlds/")
-      + "Test world/2/test.world"));
+      std::string("test_cache/fuel.ignitionrobotics.org/openrobotics/worlds/")
+      + "test world/2/test.world"));
 
   clearIOStreams(stdOutBuffer, stdErrBuffer);
   restoreIO();
@@ -500,40 +500,40 @@ TEST_P(DownloadCollectionTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(AllItems))
   // Check files
   // Model: Backpack
   EXPECT_TRUE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/OpenRobotics/models/Backpack"));
+      "test_cache/fuel.ignitionrobotics.org/openrobotics/models/backpack"));
   EXPECT_TRUE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/OpenRobotics/models/Backpack/1"));
+      "test_cache/fuel.ignitionrobotics.org/openrobotics/models/backpack/1"));
   EXPECT_TRUE(ignition::common::isFile(
-      std::string("test_cache/fuel.ignitionrobotics.org/OpenRobotics/models/") +
-      "Backpack/1/model.sdf"));
+      std::string("test_cache/fuel.ignitionrobotics.org/openrobotics/models/") +
+      "backpack/1/model.sdf"));
 
   // Model: TEAMBASE
   EXPECT_TRUE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/OpenRobotics/models/TEAMBASE"));
+      "test_cache/fuel.ignitionrobotics.org/openrobotics/models/teambase"));
   EXPECT_TRUE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/OpenRobotics/models/TEAMBASE/2"));
+      "test_cache/fuel.ignitionrobotics.org/openrobotics/models/teambase/2"));
   EXPECT_TRUE(ignition::common::isFile(
-      std::string("test_cache/fuel.ignitionrobotics.org/OpenRobotics/models/") +
-      "TEAMBASE/2/model.sdf"));
+      std::string("test_cache/fuel.ignitionrobotics.org/openrobotics/models/") +
+      "teambase/2/model.sdf"));
 
   // World: Test World
   EXPECT_TRUE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/OpenRobotics/worlds/Test world"));
+      "test_cache/fuel.ignitionrobotics.org/openrobotics/worlds/test world"));
   EXPECT_TRUE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/OpenRobotics/worlds/Test world/2"));
+      "test_cache/fuel.ignitionrobotics.org/openrobotics/worlds/test world/2"));
   EXPECT_TRUE(ignition::common::isFile(
-      std::string("test_cache/fuel.ignitionrobotics.org/OpenRobotics/worlds/") +
-      "Test world/2/test.world"));
+      std::string("test_cache/fuel.ignitionrobotics.org/openrobotics/worlds/") +
+      "test world/2/test.world"));
 
   // World: Test World 2
   EXPECT_TRUE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/OpenRobotics/worlds/Test world 2"));
+      "test_cache/fuel.ignitionrobotics.org/openrobotics/worlds/test world 2"));
   EXPECT_TRUE(
       ignition::common::isDirectory("test_cache/fuel.ignitionrobotics.org/"
-                                    "OpenRobotics/worlds/Test world 2/2"));
+                                    "openrobotics/worlds/test world 2/2"));
   EXPECT_TRUE(ignition::common::isFile(
-      std::string("test_cache/fuel.ignitionrobotics.org/OpenRobotics/worlds/") +
-      "Test world 2/2/test.world"));
+      std::string("test_cache/fuel.ignitionrobotics.org/openrobotics/worlds/") +
+      "test world 2/2/test.world"));
   clearIOStreams(stdOutBuffer, stdErrBuffer);
   restoreIO();
 }
@@ -568,29 +568,29 @@ TEST_P(DownloadCollectionTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Models))
   // Check files
   // Model: Backpack
   EXPECT_TRUE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/OpenRobotics/models/Backpack"));
+      "test_cache/fuel.ignitionrobotics.org/openrobotics/models/backpack"));
   EXPECT_TRUE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/OpenRobotics/models/Backpack/1"));
+      "test_cache/fuel.ignitionrobotics.org/openrobotics/models/backpack/1"));
   EXPECT_TRUE(ignition::common::isFile(
-      std::string("test_cache/fuel.ignitionrobotics.org/OpenRobotics/models/") +
-      "Backpack/1/model.sdf"));
+      std::string("test_cache/fuel.ignitionrobotics.org/openrobotics/models/") +
+      "backpack/1/model.sdf"));
 
   // Model: TEAMBASE
   EXPECT_TRUE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/OpenRobotics/models/TEAMBASE"));
+      "test_cache/fuel.ignitionrobotics.org/openrobotics/models/teambase"));
   EXPECT_TRUE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/OpenRobotics/models/TEAMBASE/2"));
+      "test_cache/fuel.ignitionrobotics.org/openrobotics/models/teambase/2"));
   EXPECT_TRUE(ignition::common::isFile(
-      std::string("test_cache/fuel.ignitionrobotics.org/OpenRobotics/models/") +
-      "TEAMBASE/2/model.sdf"));
+      std::string("test_cache/fuel.ignitionrobotics.org/openrobotics/models/") +
+      "teambase/2/model.sdf"));
 
   // World: Test World
   EXPECT_FALSE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/OpenRobotics/worlds/Test world"));
+      "test_cache/fuel.ignitionrobotics.org/openrobotics/worlds/test world"));
 
   // World: Test World 2
   EXPECT_FALSE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/OpenRobotics/worlds/Test world 2"));
+      "test_cache/fuel.ignitionrobotics.org/openrobotics/worlds/test world 2"));
   clearIOStreams(stdOutBuffer, stdErrBuffer);
   restoreIO();
 }
@@ -625,30 +625,30 @@ TEST_P(DownloadCollectionTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Worlds))
   // Check files
   // Model: Backpack
   EXPECT_FALSE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/OpenRobotics/models/Backpack"));
+      "test_cache/fuel.ignitionrobotics.org/openrobotics/models/backpack"));
 
   // Model: TEAMBASE
   EXPECT_FALSE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/OpenRobotics/models/TEAMBASE"));
+      "test_cache/fuel.ignitionrobotics.org/openrobotics/models/teambase"));
 
   // World: Test World
   EXPECT_TRUE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/OpenRobotics/worlds/Test world"));
+      "test_cache/fuel.ignitionrobotics.org/openrobotics/worlds/test world"));
   EXPECT_TRUE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/OpenRobotics/worlds/Test world/2"));
+      "test_cache/fuel.ignitionrobotics.org/openrobotics/worlds/test world/2"));
   EXPECT_TRUE(ignition::common::isFile(
-      std::string("test_cache/fuel.ignitionrobotics.org/OpenRobotics/worlds/") +
-      "Test world/2/test.world"));
+      std::string("test_cache/fuel.ignitionrobotics.org/openrobotics/worlds/") +
+      "test world/2/test.world"));
 
   // World: Test World 2
   EXPECT_TRUE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/OpenRobotics/worlds/Test world 2"));
+      "test_cache/fuel.ignitionrobotics.org/openrobotics/worlds/test world 2"));
   EXPECT_TRUE(
       ignition::common::isDirectory("test_cache/fuel.ignitionrobotics.org/"
-                                    "OpenRobotics/worlds/Test world 2/2"));
+                                    "openrobotics/worlds/test world 2/2"));
   EXPECT_TRUE(ignition::common::isFile(
-      std::string("test_cache/fuel.ignitionrobotics.org/OpenRobotics/worlds/") +
-      "Test world 2/2/test.world"));
+      std::string("test_cache/fuel.ignitionrobotics.org/openrobotics/worlds/") +
+      "test world 2/2/test.world"));
   clearIOStreams(stdOutBuffer, stdErrBuffer);
   restoreIO();
 }

--- a/src/ign_src_TEST.cc
+++ b/src/ign_src_TEST.cc
@@ -502,10 +502,10 @@ TEST_P(DownloadCollectionTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(AllItems))
   EXPECT_TRUE(ignition::common::isDirectory(
       "test_cache/fuel.ignitionrobotics.org/openrobotics/models/backpack"));
   EXPECT_TRUE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/openrobotics/models/backpack/1"));
+      "test_cache/fuel.ignitionrobotics.org/openrobotics/models/backpack/2"));
   EXPECT_TRUE(ignition::common::isFile(
       std::string("test_cache/fuel.ignitionrobotics.org/openrobotics/models/") +
-      "backpack/1/model.sdf"));
+      "backpack/2/model.sdf"));
 
   // Model: TEAMBASE
   EXPECT_TRUE(ignition::common::isDirectory(
@@ -570,10 +570,10 @@ TEST_P(DownloadCollectionTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Models))
   EXPECT_TRUE(ignition::common::isDirectory(
       "test_cache/fuel.ignitionrobotics.org/openrobotics/models/backpack"));
   EXPECT_TRUE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/openrobotics/models/backpack/1"));
+      "test_cache/fuel.ignitionrobotics.org/openrobotics/models/backpack/2"));
   EXPECT_TRUE(ignition::common::isFile(
       std::string("test_cache/fuel.ignitionrobotics.org/openrobotics/models/") +
-      "backpack/1/model.sdf"));
+      "backpack/2/model.sdf"));
 
   // Model: TEAMBASE
   EXPECT_TRUE(ignition::common::isDirectory(

--- a/src/ign_src_TEST.cc
+++ b/src/ign_src_TEST.cc
@@ -369,7 +369,7 @@ TEST(CmdLine, WorldListCustomServerPrettyOwner)
 
   EXPECT_NE(stdOutBuffer.str().find(
         "https://staging-fuel.ignitionrobotics.org"), std::string::npos)
-    << stdOutBuffer.str();<<<<<<< nkoenig/lowercase
+    << stdOutBuffer.str();
   EXPECT_NE(stdOutBuffer.str().find("worlds"), std::string::npos)
       << stdOutBuffer.str();
 


### PR DESCRIPTION
This will store models and worlds using lowercase name and owner. 

I've done the following tests:

1. Run SubT worlds with an existing cache that has capitalization. Result: nothing new is downloaded, and the worlds run.
2. Run SubT world with some models missing from the cache. Result: new models are downloaded to all lowercase directories.
3. Run worlds with random capitalization in model URIs. Result: utilizes existing cache, or downloads new resources.
4. Download a collection, such as `ign fuel download -v 4 -j 8 -u "https://fuel.ignitionrobotics.org/OpenRobotics/collections/SubT Tech Repo"`. Result: This will download all the models using lowercase.
5. If there is a model is two places, such as `OpenRobotics/models/X1 Config 1` and `openrobotics/x1 config 1`, then the lower case version will be used.

I think this won't break anyone, and Ignition Gazebo should still use an existing cache even if the cache has capitalization. 

Signed-off-by: Nate Koenig <nate@openrobotics.org>