### PR TITLE
Update Backpack model to fix tests

### DIFF
--- a/src/ign_src_TEST.cc
+++ b/src/ign_src_TEST.cc
@@ -502,10 +502,10 @@ TEST_P(DownloadCollectionTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(AllItems))
   EXPECT_TRUE(ignition::common::isDirectory(
       "test_cache/fuel.ignitionrobotics.org/OpenRobotics/models/Backpack"));
   EXPECT_TRUE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/OpenRobotics/models/Backpack/1"));
+      "test_cache/fuel.ignitionrobotics.org/OpenRobotics/models/Backpack/2"));
   EXPECT_TRUE(ignition::common::isFile(
       std::string("test_cache/fuel.ignitionrobotics.org/OpenRobotics/models/") +
-      "Backpack/1/model.sdf"));
+      "Backpack/2/model.sdf"));
 
   // Model: TEAMBASE
   EXPECT_TRUE(ignition::common::isDirectory(
@@ -570,10 +570,10 @@ TEST_P(DownloadCollectionTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Models))
   EXPECT_TRUE(ignition::common::isDirectory(
       "test_cache/fuel.ignitionrobotics.org/OpenRobotics/models/Backpack"));
   EXPECT_TRUE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/OpenRobotics/models/Backpack/1"));
+      "test_cache/fuel.ignitionrobotics.org/OpenRobotics/models/Backpack/2"));
   EXPECT_TRUE(ignition::common::isFile(
       std::string("test_cache/fuel.ignitionrobotics.org/OpenRobotics/models/") +
-      "Backpack/1/model.sdf"));
+      "Backpack/2/model.sdf"));
 
   // Model: TEAMBASE
   EXPECT_TRUE(ignition::common::isDirectory(


### PR DESCRIPTION
Similar to https://github.com/ignitionrobotics/ign-gazebo/pull/455

This is not the best long-term fix, but it will make the builds green again.