### PR TITLE
Set keep alive on

### DIFF
--- a/src/RestClient.cc
+++ b/src/RestClient.cc
@@ -255,6 +255,15 @@ RestResponse Rest::Request(HttpMethod _method,
     }
   }
 
+  // enable TCP keep-alive for this transfer
+  curl_easy_setopt(curl, CURLOPT_TCP_KEEPALIVE, 1L);
+
+  // keep-alive idle time to 120 seconds
+  curl_easy_setopt(curl, CURLOPT_TCP_KEEPIDLE, 120L);
+
+  // interval time between keep-alive probes: 60 seconds
+  curl_easy_setopt(curl, CURLOPT_TCP_KEEPINTVL, 60L);
+
   curl_easy_setopt(curl, CURLOPT_USERAGENT, this->userAgent.c_str());
   curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
 


### PR DESCRIPTION
This adds keepalive options to curl. The command line version of curl has this enabled by default, and I've found that these parameters help downloading large models and collections.

Reference: https://curl.se/libcurl/c/CURLOPT_TCP_KEEPALIVE.html
Reference: https://ec.haxx.se/usingcurl/usingcurl-timeouts#:~:text=By%20using%20keep%2Dalive%2C%20curl,default%20value%20is%2060%20seconds.

Signed-off-by: Nate Koenig <nate@openrobotics.org>