### PR TITLE
Fix light map URI in materials

### DIFF
--- a/src/LocalCache.cc
+++ b/src/LocalCache.cc
@@ -656,6 +656,10 @@ void LocalCachePrivate::FixPathsInMaterialElement(
             workflowElem->FirstChildElement("emissive_map");
         if (emissiveElem)
           this->FixPathsInUri(emissiveElem, _id);
+        tinyxml2::XMLElement *lightElem =
+            workflowElem->FirstChildElement("light_map");
+        if (lightElem)
+          this->FixPathsInUri(lightElem, _id);
         // metal workflow specific elements
         if (workflow == "metal")
         {


### PR DESCRIPTION
so we can convert `model://<model_name>/<path_to_texture>.png` to absolute path on local disk.

related pull request: ignitionrobotics/ign-gazebo#471

Signed-off-by: Ian Chen <ichen@osrfoundation.org>