### PR TITLE
Document IGN_FUEL_CACHE_PATH on command line

### DIFF
--- a/src/cmd/cmdfuel.rb.in
+++ b/src/cmd/cmdfuel.rb.in
@@ -57,7 +57,10 @@ COMMANDS = { 'fuel' =>
   "  -v [ --verbose ] [arg]   Adjust the level of console output (0~4).    \n"\
   "                           The default verbosity is 1, use -v without   \n"\
   "                           arguments for level 3.                       \n" +
-  COMMON_OPTIONS
+  COMMON_OPTIONS + "\n\n" +
+  "Environment variables:                                                  \n"\
+  "  IGN_FUEL_CACHE_PATH      Path to the cache where resources are        \n"\
+  " downloaded to. Defaults to $HOME/.ignition/fuel                        \n"
 }
 
 SUBCOMMANDS = {


### PR DESCRIPTION
I always forget what the exact environment variable is. I think we should start documenting all variables on the command line, like `ign-gazebo` does.