### PR TITLE
Use semantic version and prevent crash if version is missing

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -3,6 +3,7 @@ libcurl4-openssl-dev
 libgflags-dev
 libignition-cmake2-dev
 libignition-common3-dev
+libignition-math6-dev
 libignition-msgs5-dev
 libignition-tools-dev
 libjsoncpp-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,11 @@ ign_find_package(ignition-common3 REQUIRED PRIVATE)
 set(IGN_COMMON_MAJOR_VER ${ignition-common3_VERSION_MAJOR})
 
 #--------------------------------------
+# Find ignition-math
+ign_find_package(ignition-math6 REQUIRED PRIVATE)
+set(IGN_MSGS_MAJOR_VER ${ignition-math6_VERSION_MAJOR})
+
+#--------------------------------------
 # Find ignition-msgs
 ign_find_package(ignition-msgs5 REQUIRED PRIVATE)
 set(IGN_MSGS_MAJOR_VER ${ignition-msgs5_VERSION_MAJOR})

--- a/src/LocalCache.cc
+++ b/src/LocalCache.cc
@@ -32,6 +32,7 @@
 #include <ignition/common/Filesystem.hh>
 #include <ignition/common/StringUtils.hh>
 #include <ignition/common/Util.hh>
+#include <ignition/math/SemanticVersion.hh>
 
 #include "ignition/fuel_tools/ClientConfig.hh"
 #include "ignition/fuel_tools/LocalCache.hh"
@@ -459,11 +460,24 @@ bool LocalCachePrivate::FixPaths(const std::string &_modelVersionedDir,
 
   // Get the <sdf> element with the highest (most recent) version.
   tinyxml2::XMLElement *sdfElementLatest = nullptr;
-  double maxVersion = 0.0;
+  math::SemanticVersion maxVersion{"0.0"};
   tinyxml2::XMLElement *sdfElement = modelElement->FirstChildElement("sdf");
   while (sdfElement)
   {
-    double version = std::stod(sdfElement->Attribute("version"));
+    math::SemanticVersion version;
+
+    auto versionAttribute = sdfElement->Attribute("version");
+    if (nullptr == versionAttribute)
+    {
+      version.Parse("0.0.1");
+      ignwarn << "<sdf> element missing version attribute, assuming version ["
+              << version << "]" << std::endl;
+    }
+    else
+    {
+      version.Parse(versionAttribute);
+    }
+
     if (version > maxVersion)
     {
       maxVersion = version;


### PR DESCRIPTION
I was getting a crash while downloading a model with a malformed config:

```
$ ign fuel download -j 4 -v 4 -u "https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Universal Robotics UR10 robot arm"
...
terminate called after throwing an instance of 'std::logic_error'                                                                           
  what():  basic_string::_M_construct null not valid                     
Aborted (core dumped)   
```

The problem is that the `<sdf>` element of that model doesn't have a `version` attribute.

To prevent a crash, I'm assuming a version 0.0.1.

Which begs the question, is that version meant to be semantic? I don't think that has been specified anywhere. But considering that most models have a version in the format `X.X`, I think semantic versioning would make more sense than doubles. That is, `1.12` is larger than `1.2`. So I also updated the logic to use Ignition Math's `SemanticVersion` class. This adds an explicit dependency on `ign-math`, but that should be ok, because that was already an indirect dependency through `ign-common` and `ign-msgs`.