### PR TITLE
Included private-token to config.yaml

### DIFF
--- a/include/ignition/fuel_tools/ClientConfig.hh
+++ b/include/ignition/fuel_tools/ClientConfig.hh
@@ -149,7 +149,11 @@ namespace ignition
 
       /// \brief List of servers the client will connect to.
       /// \return The list of servers.
-      public: std::vector<ServerConfig> & Servers() const;
+      public: std::vector<ServerConfig> Servers() const;
+
+      /// \brief List of servers the client will connect to.
+      /// \return The list of servers.
+      public: std::vector<ServerConfig> & MutableServers() const;
 
       /// \brief Add a server to the list.
       /// \param[in] _srv The server config.

--- a/include/ignition/fuel_tools/ClientConfig.hh
+++ b/include/ignition/fuel_tools/ClientConfig.hh
@@ -149,7 +149,7 @@ namespace ignition
 
       /// \brief List of servers the client will connect to.
       /// \return The list of servers.
-      public: std::vector<ServerConfig> Servers() const;
+      public: std::vector<ServerConfig> & Servers() const;
 
       /// \brief Add a server to the list.
       /// \param[in] _srv The server config.

--- a/include/ignition/fuel_tools/FuelClient.hh
+++ b/include/ignition/fuel_tools/FuelClient.hh
@@ -377,6 +377,13 @@ namespace ignition
       public: bool ParseCollectionUrl(const common::URI &_url,
                                       CollectionIdentifier &_id);
 
+      /// \brief Checked if there is any header already specify
+      /// \param[in] _serverConfig Server configuration
+      /// \param[inout] _headers Vector with headers to check
+      private: void AddServerConfigParametersToHeaders(
+        const ignition::fuel_tools::ServerConfig &_serverConfig,
+        std::vector<std::string> &_headers) const;
+
       /// \brief PIMPL
       private: std::unique_ptr<FuelClientPrivate> dataPtr;
     };

--- a/src/ClientConfig.cc
+++ b/src/ClientConfig.cc
@@ -332,8 +332,8 @@ bool ClientConfig::LoadConfig(const std::string &_file)
               {
                 if (!privateToken.empty())
                 {
-                  ignerr << "Setted private-token header for " << serverURL << std::endl;
-                  // savedServer.AddHeader("Private-token: " + privateToken);
+                  ignerr << "Setted key for " << serverURL << " server."
+                    << std::endl;
                   savedServer.SetApiKey(privateToken);
                 }
                 else
@@ -352,8 +352,8 @@ bool ClientConfig::LoadConfig(const std::string &_file)
               newServer.SetUrl(common::URI(serverURL));
               if (!privateToken.empty())
               {
-                ignerr << "Setted private-token header for " << serverURL << std::endl;
-                // newServer.AddHeader("Private-token: " + privateToken);
+                ignerr << "Setted key for " << serverURL << " server."
+                  << std::endl;
                 newServer.SetApiKey(privateToken);
               }
             }

--- a/src/ClientConfig.cc
+++ b/src/ClientConfig.cc
@@ -326,21 +326,18 @@ bool ClientConfig::LoadConfig(const std::string &_file)
           {
             // Sanity check: Make sure that the server is not already stored.
             bool repeated = false;
-            for (auto & savedServer : this->Servers())
+            for (auto & savedServer : this->MutableServers())
             {
               if (savedServer.Url().Str() == serverURL)
               {
                 if (!privateToken.empty())
                 {
-                  ignerr << "Setted key for " << serverURL << " server."
+                  ignmsg << "Set private token for " << serverURL << " server."
                     << std::endl;
                   savedServer.SetApiKey(privateToken);
                 }
-                else
-                {
-                  ignwarn << "URL [" << serverURL << "] already exists. "
-                         << "Ignoring server" << std::endl;
-                }
+                ignwarn << "URL [" << serverURL << "] already exists. "
+                  << "Ignoring server" << std::endl;
                 repeated = true;
                 break;
               }
@@ -352,10 +349,11 @@ bool ClientConfig::LoadConfig(const std::string &_file)
               newServer.SetUrl(common::URI(serverURL));
               if (!privateToken.empty())
               {
-                ignerr << "Setted key for " << serverURL << " server."
+                ignmsg << "Set private token for " << serverURL << " server."
                   << std::endl;
                 newServer.SetApiKey(privateToken);
               }
+              this->AddServer(newServer);
             }
           }
           else
@@ -448,7 +446,13 @@ std::string ClientConfig::ConfigPath() const
 }
 
 //////////////////////////////////////////////////
-std::vector<ServerConfig> & ClientConfig::Servers() const
+std::vector<ServerConfig> ClientConfig::Servers() const
+{
+  return this->dataPtr->servers;
+}
+
+//////////////////////////////////////////////////
+std::vector<ServerConfig> & ClientConfig::MutableServers() const
 {
   return this->dataPtr->servers;
 }

--- a/src/FuelClient.cc
+++ b/src/FuelClient.cc
@@ -525,7 +525,12 @@ Result FuelClient::DeleteUrl(const ignition::common::URI &_uri,
 //////////////////////////////////////////////////
 Result FuelClient::DownloadModel(const ModelIdentifier &_id)
 {
-  return this->DownloadModel(_id, {});
+  std::vector<std::string> headers;
+  if (!_id.Server().ApiKey().empty())
+  {
+    headers.push_back("Private-token: " + _id.Server().ApiKey());
+  }
+  return this->DownloadModel(_id, headers);
 }
 
 //////////////////////////////////////////////////

--- a/src/FuelClient.cc
+++ b/src/FuelClient.cc
@@ -447,7 +447,8 @@ Result FuelClient::UploadModel(const std::string &_pathToModelDir,
     _id.Server(), headersIncludingServerConfig);
   // Send the request.
   resp = rest.Request(HttpMethod::POST_FORM, _id.Server().Url().Str(),
-      _id.Server().Version(), "models", {}, headersIncludingServerConfig, "", form);
+      _id.Server().Version(), "models", {},
+      headersIncludingServerConfig, "", form);
 
   if (resp.statusCode != 200)
   {

--- a/src/FuelClient.cc
+++ b/src/FuelClient.cc
@@ -277,8 +277,11 @@ Result FuelClient::ModelDetails(const ModelIdentifier &_id,
   common::URIPath path;
   path = path / _id.Owner() / "models" / _id.Name();
 
+  std::vector<std::string> headersIncludingServerConfig = _headers;
+  AddServerConfigParametersToHeaders(
+    _id.Server(), headersIncludingServerConfig);
   resp = rest.Request(HttpMethod::GET, serverUrl, version,
-      path.Str(), {}, _headers, "");
+      path.Str(), {}, headersIncludingServerConfig, "");
   if (resp.statusCode != 200)
     return Result(ResultType::FETCH_ERROR);
 
@@ -439,9 +442,12 @@ Result FuelClient::UploadModel(const std::string &_pathToModelDir,
   if (!this->dataPtr->FillModelForm(_pathToModelDir, _id, _private, form))
     return Result(ResultType::UPLOAD_ERROR);
 
+  std::vector<std::string> headersIncludingServerConfig = _headers;
+  AddServerConfigParametersToHeaders(
+    _id.Server(), headersIncludingServerConfig);
   // Send the request.
   resp = rest.Request(HttpMethod::POST_FORM, _id.Server().Url().Str(),
-      _id.Server().Version(), "models", {}, _headers, "", form);
+      _id.Server().Version(), "models", {}, headersIncludingServerConfig, "", form);
 
   if (resp.statusCode != 200)
   {
@@ -464,6 +470,27 @@ Result FuelClient::DeleteModel(const ModelIdentifier &)
   return Result(ResultType::DELETE_ERROR);
 }
 
+void FuelClient::AddServerConfigParametersToHeaders(
+  const ignition::fuel_tools::ServerConfig &_serverConfig,
+  std::vector<std::string> &_headers) const
+{
+  bool privateTokenDefined = false;
+  for (auto header : _headers)
+  {
+    if (header.find("Private-token:") != std::string::npos)
+    {
+      privateTokenDefined = true;
+    }
+  }
+  if (!privateTokenDefined)
+  {
+    if (!_serverConfig.ApiKey().empty())
+    {
+      _headers.push_back("Private-token: " + _serverConfig.ApiKey());
+    }
+  }
+}
+
 //////////////////////////////////////////////////
 Result FuelClient::DeleteUrl(const ignition::common::URI &_uri,
     const std::vector<std::string> &_headers)
@@ -479,6 +506,7 @@ Result FuelClient::DeleteUrl(const ignition::common::URI &_uri,
 
   ModelIdentifier modelId;
   WorldIdentifier worldId;
+  std::vector<std::string> headersIncludingServerConfig = _headers;
   if (this->ParseModelUrl(_uri, modelId))
   {
     type = "model";
@@ -486,6 +514,8 @@ Result FuelClient::DeleteUrl(const ignition::common::URI &_uri,
     server = modelId.Server().Url().Str();
     version = modelId.Server().Version();
     path = path / modelId.Owner() / "models" / modelId.Name();
+    AddServerConfigParametersToHeaders(
+      modelId.Server(), headersIncludingServerConfig);
   }
   else if (this->ParseWorldUrl(_uri, worldId))
   {
@@ -494,6 +524,8 @@ Result FuelClient::DeleteUrl(const ignition::common::URI &_uri,
     server = worldId.Server().Url().Str();
     version = worldId.Server().Version();
     path = path / worldId.Owner() / "worlds" / worldId.Name();
+    AddServerConfigParametersToHeaders(
+      worldId.Server(), headersIncludingServerConfig);
   }
   else
   {
@@ -503,7 +535,7 @@ Result FuelClient::DeleteUrl(const ignition::common::URI &_uri,
 
   // Send the request.
   resp = rest.Request(HttpMethod::DELETE, server, version, path.Str(), {},
-      _headers, "", {});
+      headersIncludingServerConfig, "", {});
 
   if (resp.statusCode != 200)
   {
@@ -525,12 +557,7 @@ Result FuelClient::DeleteUrl(const ignition::common::URI &_uri,
 //////////////////////////////////////////////////
 Result FuelClient::DownloadModel(const ModelIdentifier &_id)
 {
-  std::vector<std::string> headers;
-  if (!_id.Server().ApiKey().empty())
-  {
-    headers.push_back("Private-token: " + _id.Server().ApiKey());
-  }
-  return this->DownloadModel(_id, headers);
+  return this->DownloadModel(_id, {});
 }
 
 //////////////////////////////////////////////////
@@ -552,11 +579,15 @@ Result FuelClient::DownloadModel(const ModelIdentifier &_id,
 
   ignmsg << "Downloading model [" << _id.UniqueName() << "]" << std::endl;
 
+  std::vector<std::string> headersIncludingServerConfig = _headers;
+  AddServerConfigParametersToHeaders(
+    _id.Server(), headersIncludingServerConfig);
   // Request
   ignition::fuel_tools::Rest rest;
   RestResponse resp;
   resp = rest.Request(HttpMethod::GET, _id.Server().Url().Str(),
-      _id.Server().Version(), route.Str(), {}, _headers, "");
+      _id.Server().Version(), route.Str(), {},
+      headersIncludingServerConfig, "");
   if (resp.statusCode != 200)
   {
     ignerr << "Failed to download model." << std::endl
@@ -664,17 +695,16 @@ Result FuelClient::DownloadWorld(WorldIdentifier &_id)
 
   ignmsg << "Downloading world [" << _id.UniqueName() << "]" << std::endl;
 
-  std::vector<std::string> headers;
-  if (!_id.Server().ApiKey().empty())
-  {
-    headers.push_back("Private-token: " + _id.Server().ApiKey());
-  }
+  std::vector<std::string> headersIncludingServerConfig;
+  AddServerConfigParametersToHeaders(
+    _id.Server(), headersIncludingServerConfig);
 
   // Request
   ignition::fuel_tools::Rest rest;
   RestResponse resp;
   resp = rest.Request(HttpMethod::GET, _id.Server().Url().Str(),
-      _id.Server().Version(), route.Str(), {}, headers, "");
+      _id.Server().Version(), route.Str(), {},
+      headersIncludingServerConfig, "");
   if (resp.statusCode != 200)
   {
     ignerr << "Failed to download world." << std::endl
@@ -1276,8 +1306,11 @@ Result FuelClient::PatchModel(
     form.emplace("private", _model.Private() ? "1" : "0");
   }
 
+  std::vector<std::string> headersIncludingServerConfig = _headers;
+  AddServerConfigParametersToHeaders(
+    _model.Server(), headersIncludingServerConfig);
   resp = rest.Request(HttpMethod::PATCH_FORM, serverUrl, version,
-      path.Str(), {}, _headers, "", form);
+      path.Str(), {}, headersIncludingServerConfig, "", form);
 
   if (resp.statusCode != 200)
     return Result(ResultType::PATCH_ERROR);

--- a/src/FuelClient.cc
+++ b/src/FuelClient.cc
@@ -664,11 +664,17 @@ Result FuelClient::DownloadWorld(WorldIdentifier &_id)
 
   ignmsg << "Downloading world [" << _id.UniqueName() << "]" << std::endl;
 
+  std::vector<std::string> headers;
+  if (!_id.Server().ApiKey().empty())
+  {
+    headers.push_back("Private-token: " + _id.Server().ApiKey());
+  }
+
   // Request
   ignition::fuel_tools::Rest rest;
   RestResponse resp;
   resp = rest.Request(HttpMethod::GET, _id.Server().Url().Str(),
-      _id.Server().Version(), route.Str(), {}, {}, "");
+      _id.Server().Version(), route.Str(), {}, headers, "");
   if (resp.statusCode != 200)
   {
     ignerr << "Failed to download world." << std::endl

--- a/tutorials/02_configuration.md
+++ b/tutorials/02_configuration.md
@@ -16,6 +16,7 @@ Ignition Fuel Tools accepts a YAML file with the following syntax:
 servers:
   -
     url: https://fuel.ignitionrobotics.org
+    private-token: <your private token>
 
   # -
     # url: https://myserver
@@ -27,6 +28,7 @@ servers:
 
 The `servers` section specifies all Fuel servers to interact with.
 For each server, you must specify the URL to send the HTTP requests.
+If the server requires auth you can specify the token filling the optional field `private-token`.
 
 The `cache` section captures options related with the local storage of the
 assets. `path` specifies the local directory where all assets will be

--- a/tutorials/03_command_line.md
+++ b/tutorials/03_command_line.md
@@ -88,6 +88,24 @@ Downloading world:
 Download succeeded.
 ```
 
+If the model is privated you can create a config file with your token. For example, create a file
+`/tmp/my_config.yaml` with the following content and edit your token:
+
+```yaml
+---
+# The list of servers.
+servers:
+  -
+    url: https://fuel.ignitionrobotics.org
+    private-token: <your private token>
+```
+
+Then try to download the model:
+
+```bash
+ign fuel download -v 4 -u https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Empty -c /tmp/my_config.yaml
+```
+
 Worlds downloaded with the tool get conveniently organized into the same
 directory, which we call the "local cache". The path is broken down as follows:
 


### PR DESCRIPTION
Related with this issue: https://github.com/ignitionrobotics/ign-fuel-tools/issues/155

Included a new field called `private-token` to allow the identification with the server using the yaml file.

Signed-off-by: ahcorde <ahcorde@gmail.com>