### PR TITLE
Bump in edifice: ign-msgs7

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -3,7 +3,7 @@ libcurl4-openssl-dev
 libgflags-dev
 libignition-cmake2-dev
 libignition-common3-dev
-libignition-msgs6-dev
+libignition-msgs7-dev
 libignition-tools-dev
 libjsoncpp-dev
 libtinyxml2-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,8 +52,8 @@ set(IGN_COMMON_MAJOR_VER ${ignition-common3_VERSION_MAJOR})
 
 #--------------------------------------
 # Find ignition-msgs
-ign_find_package(ignition-msgs6 REQUIRED PRIVATE)
-set(IGN_MSGS_MAJOR_VER ${ignition-msgs6_VERSION_MAJOR})
+ign_find_package(ignition-msgs7 REQUIRED PRIVATE)
+set(IGN_MSGS_MAJOR_VER ${ignition-msgs7_VERSION_MAJOR})
 
 #--------------------------------------
 # Find ignition-tools

--- a/configure.bat
+++ b/configure.bat
@@ -11,7 +11,7 @@ call %win_lib% :download_unzip_install libzip-1.4.0_zlip-1.2.11_vc15-x64-dll-MD.
 call %win_lib% :install_ign_project ign-cmake ign-cmake2
 call %win_lib% :install_ign_project ign-tools ign-tools1
 call %win_lib% :install_ign_project ign-common ign-common3
-call %win_lib% :install_ign_project ign-msgs master
+call %win_lib% :install_ign_project ign-msgs main
 
 :: Set configuration variables
 @set build_type=Release

--- a/include/ignition/fuel_tools/FuelClient.hh
+++ b/include/ignition/fuel_tools/FuelClient.hh
@@ -177,7 +177,7 @@ namespace ignition
       /// \brief Remove a model from ignition fuel
       /// \param[in] _id The model identifier.
       /// \return Result of the delete operation
-      /// Deprecate this function in ign-fuel-tools5. DeleteUrl
+      /// Deprecate this function in ign-fuel-tools6. DeleteUrl
       /// replaces this function.
       public: Result DeleteModel(const ModelIdentifier &_id);
 

--- a/tutorials/01_installation.md
+++ b/tutorials/01_installation.md
@@ -26,7 +26,7 @@ Install Ignition Fuel Tools:
 
 ```
 sudo apt-get update
-sudo apt-get install libignition-fuel-tools5-dev
+sudo apt-get install libignition-fuel-tools6-dev
 ```
 
 ## Mac OS X
@@ -51,7 +51,7 @@ Run the following commands:
 
 ```
 brew tap osrf/simulation
-brew install ignition-fuel-tools5
+brew install ignition-fuel-tools6
 ```
 
 ## Windows
@@ -67,7 +67,7 @@ Make sure you have removed the Ubuntu pre-compiled binaries before
 installing from source:
 
 ```
-sudo apt-get remove libignition-fuel-tools5-dev
+sudo apt-get remove libignition-fuel-tools6-dev
 ```
 
 Install prerequisites. A clean Ubuntu system will need:

--- a/tutorials/02_configuration.md
+++ b/tutorials/02_configuration.md
@@ -62,13 +62,13 @@ mkdir /tmp/conf_tutorial && cd /tmp/conf_tutorial
 Download the file `download.cc` and save it under `/tmp/conf_tutorial`:
 
 ```
-wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools5/example/download.cc
+wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools6/example/download.cc
 ```
 
 Also, download `CMakeLists.txt` for compiling the example:
 
 ```
-wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools5/example/CMakeLists.txt
+wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools6/example/CMakeLists.txt
 ```
 
 Install a dependency:

--- a/tutorials/04_cpp_api.md
+++ b/tutorials/04_cpp_api.md
@@ -17,10 +17,10 @@ Download the files `list.cc`, `details.cc`, `download.cc`,
 `CMakeLists.txt`, and save them under `/tmp/fuel_tutorial`:
 
 ```
-wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools5/example/list.cc
-wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools5/example/details.cc
-wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools5/example/download.cc
-wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools5/example/CMakeLists.txt
+wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools6/example/list.cc
+wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools6/example/details.cc
+wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools6/example/download.cc
+wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools6/example/CMakeLists.txt
 ```
 
 Let's start by compiling the examples:


### PR DESCRIPTION
Part of https://github.com/ignition-tooling/release-tools/issues/362.

The script also updated some `ign-fuel-tools5` that was left in the `main` branch.

Supersedes https://github.com/ignitionrobotics/ign-fuel-tools/pull/152/