### PR TITLE
Edifice deprecations

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -1,3 +1,20 @@
+## Ignition Fuel Tools 5.X to 6.X
+
+### Deprecations
+
+* **Deprecation**: `FuelClient::DeleteModel`
+* **Replacement**: `FielClient::DeleteUrl`
+
+* **Deprecation**: `FuelClient` constructor that takes `LocalCache`
+* **Replacement**: `FielClient` constructor without `LocalCache`
+
+## Ignition Fuel Tools 4.X to 5.X
+
+### Deprecations
+
+* **Deprecation**: `LocalCache`
+* **Replacement**: None
+
 ## Ignition Fuel Tools 3.X to 4.X
 
 ### Modifications

--- a/include/ignition/fuel_tools/FuelClient.hh
+++ b/include/ignition/fuel_tools/FuelClient.hh
@@ -57,14 +57,21 @@ namespace ignition
       /// \brief Constructor accepts server and auth configuration
       /// \param[in] _config configuration about servers to connect to
       /// \param[in] _rest A REST request.
+      /// \remarks the client saves a copy of the config passed into it
+      public: FuelClient(const ClientConfig &_config,
+                         const Rest &_rest = Rest());
+
+      /// \brief Constructor accepts server and auth configuration
+      /// \param[in] _config configuration about servers to connect to
+      /// \param[in] _rest A REST request.
       /// \param[in] _cache Test hook. Pointer to a local cache. The FuelClient
       ///            will take ownership of the pointer and free it when
       ///            destructed. If set to nullptr the client will instantiate
       ///            it's own cache.
       /// \remarks the client saves a copy of the config passed into it
-      public: FuelClient(const ClientConfig &_config,
-                         const Rest &_rest = Rest(),
-                         LocalCache *_cache = nullptr);
+      public: IGN_DEPRECATED(6) FuelClient(const ClientConfig &_config,
+                                           const Rest &_rest,
+                                           LocalCache *_cache);
 
       /// \brief Destructor
       public: ~FuelClient();
@@ -177,9 +184,7 @@ namespace ignition
       /// \brief Remove a model from ignition fuel
       /// \param[in] _id The model identifier.
       /// \return Result of the delete operation
-      /// Deprecate this function in ign-fuel-tools5. DeleteUrl
-      /// replaces this function.
-      public: Result DeleteModel(const ModelIdentifier &_id);
+      public: Result IGN_DEPRECATED(6) DeleteModel(const ModelIdentifier &_id);
 
       /// \brief Remove a resource, such as a model or world, from Ignition Fuel
       /// \param[in] _uri The full URI of the resource, e.g:

--- a/src/FuelClient.cc
+++ b/src/FuelClient.cc
@@ -232,10 +232,15 @@ FuelClient::FuelClient(const ClientConfig &_config, const Rest &_rest)
 #ifndef _WIN32
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#else
+# pragma warning(push)
+# pragma warning(disable: 4996)
 #endif
   this->dataPtr->cache = std::make_unique<LocalCache>(&(this->dataPtr->config));
 #ifndef _WIN32
 # pragma GCC diagnostic pop
+#else
+# pragma warning(pop)
 #endif
 
   this->dataPtr->urlModelRegex.reset(new std::regex(

--- a/src/FuelClient.cc
+++ b/src/FuelClient.cc
@@ -217,34 +217,26 @@ class ignition::fuel_tools::FuelClientPrivate
 
 //////////////////////////////////////////////////
 FuelClient::FuelClient()
-  : FuelClient(ClientConfig(), Rest(), nullptr)
+  : FuelClient(ClientConfig(), Rest())
 {
 }
 
 //////////////////////////////////////////////////
-FuelClient::FuelClient(const ClientConfig &_config, const Rest &_rest,
-    LocalCache *_cache)
-  : dataPtr(new FuelClientPrivate)
+FuelClient::FuelClient(const ClientConfig &_config, const Rest &_rest)
+  : dataPtr(std::make_unique<FuelClientPrivate>())
 {
   this->dataPtr->config = _config;
   this->dataPtr->rest = _rest;
   this->dataPtr->rest.SetUserAgent(this->dataPtr->config.UserAgent());
 
-  if (nullptr == _cache)
-  {
 #ifndef _WIN32
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
-    this->dataPtr->cache.reset(new LocalCache(&(this->dataPtr->config)));
+  this->dataPtr->cache = std::make_unique<LocalCache>(&(this->dataPtr->config));
 #ifndef _WIN32
 # pragma GCC diagnostic pop
 #endif
-  }
-  else
-  {
-    this->dataPtr->cache.reset(_cache);
-  }
 
   this->dataPtr->urlModelRegex.reset(new std::regex(
     this->dataPtr->kModelUrlRegexStr));
@@ -256,6 +248,14 @@ FuelClient::FuelClient(const ClientConfig &_config, const Rest &_rest,
     this->dataPtr->kWorldFileUrlRegexStr));
   this->dataPtr->urlCollectionRegex.reset(new std::regex(
     this->dataPtr->kCollectionUrlRegexStr));
+}
+
+//////////////////////////////////////////////////
+FuelClient::FuelClient(const ClientConfig &_config, const Rest &_rest,
+      LocalCache *_cache) : FuelClient(_config, _rest)
+{
+  if (_cache != nullptr)
+    this->dataPtr->cache.reset(_cache);
 }
 
 //////////////////////////////////////////////////

--- a/src/FuelClient_TEST.cc
+++ b/src/FuelClient_TEST.cc
@@ -1342,7 +1342,14 @@ TEST_F(FuelClientTest, DeleteModelFail)
   FuelClient client;
   ModelIdentifier modelId;
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   Result result = client.DeleteModel(modelId);
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
   EXPECT_EQ(ResultType::DELETE_ERROR, result.Type());
 }
 


### PR DESCRIPTION
Deprecated `FuelClient::DeleteModel`.

`LocalCache` is deprecated in v5, but it can't be removed in v6 because it's used in a public constructor of `FuelClient`. So I deprecated that constructor and we can only move `LocalCache` to `src` in v7.