### PR TITLE
Bump main to 7.0.0~pre1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-fuel_tools6 VERSION 6.0.0)
+project(ignition-fuel_tools7 VERSION 7.0.0)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## Ignition Fuel Tools 7.x
+
+### Ignition Fuel Tools 7.0.0 (20XX-XX-XX)
+
 ## Ignition Fuel Tools 6.x
 
 ### Ignition Fuel Tools 6.0.0 (20XX-XX-XX)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 
 # Find the Ignition Fuel Tools library
-find_package(ignition-fuel_tools6 QUIET REQUIRED)
+find_package(ignition-fuel_tools7 QUIET REQUIRED)
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${IGNITION-FUEL-TOOLS_CXX_FLAGS}")
 include_directories(
   ${IGNITION-COMMON_INCLUDE_DIRS}

--- a/tutorials/01_installation.md
+++ b/tutorials/01_installation.md
@@ -24,7 +24,7 @@ wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 Install Ignition Fuel Tools:
 ```
 sudo apt-get update
-sudo apt-get install libignition-fuel-tools6-dev
+sudo apt-get install libignition-fuel-tools7-dev
 ```
 
 ### Mac OS X
@@ -47,7 +47,7 @@ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/
 Run the following commands:
 ```
 brew tap osrf/simulation
-brew install ignition-fuel-tools6
+brew install ignition-fuel-tools7
 ```
 
 ### Windows
@@ -81,7 +81,7 @@ Make sure you have removed the Ubuntu pre-compiled binaries before
 installing from source:
 
 ```
-sudo apt-get remove libignition-fuel-tools6-dev
+sudo apt-get remove libignition-fuel-tools7-dev
 ```
 
 Install prerequisites. A clean Ubuntu system will need:

--- a/tutorials/02_configuration.md
+++ b/tutorials/02_configuration.md
@@ -65,26 +65,26 @@ Download the file `download.cc` and save it under `/tmp/conf_tutorial`:
 
 ```bash
 # Ubuntu and MacOS
-wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools6/example/download.cc
+wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/main/example/download.cc
 
 # Windows
 ## CMD
-curl -sk https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools6/example/download.cc -o download.cc
+curl -sk https://github.com/ignitionrobotics/ign-fuel-tools/raw/main/example/download.cc -o download.cc
 ## PowerShell
-curl https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools6/example/download.cc -o download.cc
+curl https://github.com/ignitionrobotics/ign-fuel-tools/raw/main/example/download.cc -o download.cc
 ```
 
 Also, download `CMakeLists.txt` for compiling the example:
 
 ```bash
 # Ubuntu and MacOS
-wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools6/example/CMakeLists.txt
+wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/main/example/CMakeLists.txt
 
 # Windows
 ## CMD
-curl -sk https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools6/example/CMakeLists.txt -o CMakeLists.txt
+curl -sk https://github.com/ignitionrobotics/ign-fuel-tools/raw/main/example/CMakeLists.txt -o CMakeLists.txt
 ## PowerShell
-curl https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools6/example/CMakeLists.txt -o CMakeLists.txt
+curl https://github.com/ignitionrobotics/ign-fuel-tools/raw/main/example/CMakeLists.txt -o CMakeLists.txt
 ```
 
 Install a dependency:

--- a/tutorials/04_cpp_api.md
+++ b/tutorials/04_cpp_api.md
@@ -18,22 +18,22 @@ Download the files `list.cc`, `details.cc`, `download.cc`,
 
 ```bash
 # Ubuntu or MacOS
-wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools6/example/list.cc
-wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools6/example/details.cc
-wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools6/example/download.cc
-wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools6/example/CMakeLists.txt
+wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/main/example/list.cc
+wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/main/example/details.cc
+wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/main/example/download.cc
+wget https://github.com/ignitionrobotics/ign-fuel-tools/raw/main/example/CMakeLists.txt
 
 # Windows
 ## CMD
-curl -sk https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools6/example/list.cc -o list.cc
-curl -sk https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools6/example/details.cc -o details.cc
-curl -sk https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools6/example/download.cc -o download.cc
-curl -sk https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools6/example/CMakeLists.txt -o CMakeLists.txt
+curl -sk https://github.com/ignitionrobotics/ign-fuel-tools/raw/main/example/list.cc -o list.cc
+curl -sk https://github.com/ignitionrobotics/ign-fuel-tools/raw/main/example/details.cc -o details.cc
+curl -sk https://github.com/ignitionrobotics/ign-fuel-tools/raw/main/example/download.cc -o download.cc
+curl -sk https://github.com/ignitionrobotics/ign-fuel-tools/raw/main/example/CMakeLists.txt -o CMakeLists.txt
 ## PowerShell
-curl https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools6/example/list.cc -o list.cc
-curl https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools6/example/details.cc -o details.cc
-curl https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools6/example/download.cc -o download.cc
-curl https://github.com/ignitionrobotics/ign-fuel-tools/raw/ign-fuel-tools6/example/CMakeLists.txt -o CMakeLists.txt
+curl https://github.com/ignitionrobotics/ign-fuel-tools/raw/main/example/list.cc -o list.cc
+curl https://github.com/ignitionrobotics/ign-fuel-tools/raw/main/example/details.cc -o details.cc
+curl https://github.com/ignitionrobotics/ign-fuel-tools/raw/main/example/download.cc -o download.cc
+curl https://github.com/ignitionrobotics/ign-fuel-tools/raw/main/example/CMakeLists.txt -o CMakeLists.txt
 ```
 
 Let's start by compiling the examples:


### PR DESCRIPTION
Branch `ign-fuel-tools6` has been created for the Edifice release and 6.0.0 released from that.

The `main` branch now corresponds to version 7.0.0~pre1, and nightlies will soon be created from this branch.

https://github.com/ignition-tooling/release-tools/issues/421