### PR TITLE
added fuel update command

### DIFF
--- a/include/ignition/fuel_tools/FuelClient.hh
+++ b/include/ignition/fuel_tools/FuelClient.hh
@@ -391,6 +391,10 @@ namespace ignition
       public: bool ParseCollectionUrl(const common::URI &_url,
                                       CollectionIdentifier &_id);
 
+      public: bool UpdateModels();
+
+      public: bool UpdateWorlds();
+
       /// \brief Checked if there is any header already specify
       /// \param[in] _serverConfig Server configuration
       /// \param[inout] _headers Vector with headers to check

--- a/include/ignition/fuel_tools/FuelClient.hh
+++ b/include/ignition/fuel_tools/FuelClient.hh
@@ -223,6 +223,14 @@ namespace ignition
       /// \return Result of the download operation
       public: Result DownloadWorld(WorldIdentifier &_id);
 
+      /// \brief Download a world from Ignition Fuel. This will override an
+      /// existing local copy of the world.
+      /// \param[out] _id The world identifier, with local path updated.
+      /// \param[in] _headers Headers to set on the HTTP request.
+      /// \return Result of the download operation
+      public: Result DownloadWorld(WorldIdentifier &_id,
+                  const std::vector<std::string> &_headers);
+
       /// \brief Download a model from ignition fuel. This will override an
       /// existing local copy of the model.
       /// \param[in] _modelUrl The unique URL of the model to download.

--- a/include/ignition/fuel_tools/FuelClient.hh
+++ b/include/ignition/fuel_tools/FuelClient.hh
@@ -392,12 +392,14 @@ namespace ignition
                                       CollectionIdentifier &_id);
 
       /// \brief Update all models in local cache.
+      /// \param[in] _headers Headers to set on the HTTP request.
       /// \return True if everything updated successfully.
-      public: bool UpdateModels();
+      public: bool UpdateModels(const std::vector<std::string> &_headers);
 
       /// \brief Update all worlds in local cache.
+      /// \param[in] _headers Headers to set on the HTTP request.
       /// \return True if everything updated successfully.
-      public: bool UpdateWorlds();
+      public: bool UpdateWorlds(const std::vector<std::string> &_headers);
 
       /// \brief Checked if there is any header already specify
       /// \param[in] _serverConfig Server configuration

--- a/include/ignition/fuel_tools/FuelClient.hh
+++ b/include/ignition/fuel_tools/FuelClient.hh
@@ -85,6 +85,7 @@ namespace ignition
       /// \param[in] _id a partially filled out identifier used to fetch models
       /// \remarks Fulfills Get-One requirement
       /// \param[out] _model The requested model
+      /// \param[in] _headers Headers to set on the HTTP request.
       /// \return Result of the fetch operation.
       public: Result ModelDetails(const ModelIdentifier &_id,
                   ModelIdentifier &_model,
@@ -119,6 +120,15 @@ namespace ignition
       /// \return Result of the fetch operation.
       public: Result WorldDetails(const WorldIdentifier &_id,
                                   WorldIdentifier &_world) const;
+
+      /// \brief Fetch the details of a world.
+      /// \param[in] _id a partially filled out identifier used to fetch worlds
+      /// \param[out] _world The requested world
+      /// \param[in] _headers Headers to set on the HTTP request.
+      /// \return Result of the fetch operation.
+      public: Result WorldDetails(const WorldIdentifier &_id,
+                                WorldIdentifier &_world,
+                                const std::vector<std::string> &_headers) const;
 
       /// \brief Returns an iterator that can return information of worlds
       /// \remarks An iterator instead of a list of names, to be able to

--- a/include/ignition/fuel_tools/FuelClient.hh
+++ b/include/ignition/fuel_tools/FuelClient.hh
@@ -391,8 +391,12 @@ namespace ignition
       public: bool ParseCollectionUrl(const common::URI &_url,
                                       CollectionIdentifier &_id);
 
+      /// \brief Update all models in local cache.
+      /// \return True if everything updated successfully.
       public: bool UpdateModels();
 
+      /// \brief Update all worlds in local cache.
+      /// \return True if everything updated successfully.
       public: bool UpdateWorlds();
 
       /// \brief Checked if there is any header already specify

--- a/include/ignition/fuel_tools/WorldIter.hh
+++ b/include/ignition/fuel_tools/WorldIter.hh
@@ -70,6 +70,10 @@ namespace ignition
       /// \return Internal world identifier
       public: WorldIdentifier *operator->();
 
+      /// \brief Derefence operator
+      /// \return Internal world identifier
+      public: WorldIdentifier &operator*();
+
       /// \brief Private data pointer.
       private: std::unique_ptr<WorldIterPrivate> dataPtr;
     };

--- a/src/CollectionIdentifier_TEST.cc
+++ b/src/CollectionIdentifier_TEST.cc
@@ -68,15 +68,15 @@ TEST(CollectionIdentifier, UniqueName)
   EXPECT_EQ("https://localhost:8003/alice/collections/hello", id.UniqueName());
 #else
   id.SetServer(srv1);
-  EXPECT_EQ("https://localhost:8001\\alice\\collections\\hello",
+  EXPECT_EQ("https://localhost:8001/alice/collections/hello",
       id.UniqueName());
 
   id.SetServer(srv2);
-  EXPECT_EQ("https://localhost:8002\\alice\\collections\\hello",
+  EXPECT_EQ("https://localhost:8002/alice/collections/hello",
       id.UniqueName());
 
   id.SetServer(srv3);
-  EXPECT_EQ("https://localhost:8003\\alice\\collections\\hello",
+  EXPECT_EQ("https://localhost:8003/alice/collections/hello",
       id.UniqueName());
 #endif
 }

--- a/src/CollectionIdentifier_TEST.cc
+++ b/src/CollectionIdentifier_TEST.cc
@@ -136,7 +136,7 @@ TEST(CollectionIdentifier, AsString)
     std::string str =
         "Name: \n"\
         "Owner: \n"\
-        "Unique name: https://fuel.ignitionrobotics.org//collections/\n"
+        "Unique name: https://fuel.ignitionrobotics.org/collections/\n"
         "Server:\n"
         "  URL: https://fuel.ignitionrobotics.org\n"
         "  Version: 1.0\n"
@@ -145,7 +145,7 @@ TEST(CollectionIdentifier, AsString)
     std::string str =
         "Name: \n"\
         "Owner: \n"\
-        "Unique name: https://fuel.ignitionrobotics.org\\collections\n"
+        "Unique name: https://fuel.ignitionrobotics.org/collections\n"
         "Server:\n"
         "  URL: https://fuel.ignitionrobotics.org\n"
         "  Version: 1.0\n"

--- a/src/FuelClient.cc
+++ b/src/FuelClient.cc
@@ -1569,15 +1569,11 @@ void FuelClientPrivate::PopulateLicenses(const ServerConfig &_server)
 
 bool FuelClient::UpdateModels()
 {
-  ignmsg << "Updating models" << std::endl;
   std::vector<std::string> done_files;
   for (ModelIter iter = this->dataPtr->cache->AllModels(); iter; ++iter)
   {
     ignition::fuel_tools::ModelIdentifier id = iter->Identification();
     ignition::fuel_tools::ModelIdentifier cloud_id;
-    std::string urlStr = "https://fuel.ignitionrobotics.org/1.0/";
-    urlStr += id.Owner() + "/models/" + id.Name();
-    ignition::common::URI url(urlStr);
     if (!this->ModelDetails(id, cloud_id))
     {
       ignerr << "Failed to fetch model details for model["
@@ -1593,21 +1589,16 @@ bool FuelClient::UpdateModels()
       done_files.push_back(id.Name());
     }
   }
-  ignmsg << "Finished updating models" << std::endl;
   return true;
 }
 
 bool FuelClient::UpdateWorlds()
 {
-  ignmsg << "Updating Worlds" << std::endl;
   std::vector<std::string> done_files;
   for (WorldIter iter = this->dataPtr->cache->AllWorlds(); iter; ++iter)
   {
     ignition::fuel_tools::WorldIdentifier id = iter;
     ignition::fuel_tools::WorldIdentifier cloud_id;
-    std::string urlStr = "https://fuel.ignitionrobotics.org/1.0/";
-    urlStr += id.Owner() + "/worlds/" + id.Name();
-    ignition::common::URI url(urlStr);
     if (!this->WorldDetails(id, cloud_id))
     {
       ignerr << "Failed to fetch world details for world["
@@ -1623,6 +1614,5 @@ bool FuelClient::UpdateWorlds()
       done_files.push_back(id.Name());
     }
   }
-  ignmsg << "Finished updating worlds" << std::endl;
   return true;
 }

--- a/src/FuelClient.cc
+++ b/src/FuelClient.cc
@@ -1567,7 +1567,7 @@ void FuelClientPrivate::PopulateLicenses(const ServerConfig &_server)
   }
 }
 
-bool FuelClient::UpdateModels()
+bool FuelClient::UpdateModels(const std::vector<std::string> &_headers)
 {
   std::vector<std::string> done_files;
   for (ModelIter iter = this->dataPtr->cache->AllModels(); iter; ++iter)
@@ -1585,14 +1585,14 @@ bool FuelClient::UpdateModels()
     {
       ignmsg << "Updating model " << id.Name() << " up to version "
       << cloud_id.Version() << std::endl;
-      this->DownloadModel(cloud_id);
+      this->DownloadModel(cloud_id, _headers);
       done_files.push_back(id.Name());
     }
   }
   return true;
 }
 
-bool FuelClient::UpdateWorlds()
+bool FuelClient::UpdateWorlds(const std::vector<std::string> &/*_headers*/)
 {
   std::vector<std::string> done_files;
   for (WorldIter iter = this->dataPtr->cache->AllWorlds(); iter; ++iter)
@@ -1610,7 +1610,7 @@ bool FuelClient::UpdateWorlds()
     {
       ignmsg << "Updating world " << id.Name() << " up to version "
       << cloud_id.Version() << std::endl;
-      this->DownloadWorld(cloud_id);
+      this->DownloadWorld(cloud_id); // There is no header version for this
       done_files.push_back(id.Name());
     }
   }

--- a/src/FuelClient.cc
+++ b/src/FuelClient.cc
@@ -1630,8 +1630,6 @@ bool FuelClient::UpdateModels(const std::vector<std::string> &_headers)
 //////////////////////////////////////////////////
 bool FuelClient::UpdateWorlds(const std::vector<std::string> &_headers)
 {
-  std::cout << "Updating worlds\n";
-
   // Get a list of the most recent world versions in the cache.
   std::map<std::string, ignition::fuel_tools::WorldIdentifier> toProcess;
   for (WorldIter iter = this->dataPtr->cache->AllWorlds(); iter; ++iter)

--- a/src/ModelIdentifier_TEST.cc
+++ b/src/ModelIdentifier_TEST.cc
@@ -153,7 +153,7 @@ TEST(ModelIdentifier, AsString)
         "Name: \n"\
         "Owner: \n"\
         "Version: tip\n"\
-        "Unique name: https://fuel.ignitionrobotics.org//models/\n"
+        "Unique name: https://fuel.ignitionrobotics.org/models/\n"
         "Description: \n"
         "File size: 0\n"
         "Upload date: 0\n"
@@ -172,7 +172,7 @@ TEST(ModelIdentifier, AsString)
         "Name: \n"\
         "Owner: \n"\
         "Version: tip\n"\
-        "Unique name: https://fuel.ignitionrobotics.org\\models\n"
+        "Unique name: https://fuel.ignitionrobotics.org/models\n"
         "Description: \n"
         "File size: 0\n"
         "Upload date: 0\n"

--- a/src/WorldIdentifier_TEST.cc
+++ b/src/WorldIdentifier_TEST.cc
@@ -131,7 +131,7 @@ TEST(WorldIdentifier, AsString)
         "Name: \n"\
         "Owner: \n"\
         "Version: tip\n"\
-        "Unique name: fuel.ignitionrobotics.org/worlds\n"
+        "Unique name: fuel.ignitionrobotics.org\\worlds\n"
         "Local path: \n"
         "Server:\n"
         "  URL: https://fuel.ignitionrobotics.org\n"

--- a/src/WorldIdentifier_TEST.cc
+++ b/src/WorldIdentifier_TEST.cc
@@ -120,7 +120,7 @@ TEST(WorldIdentifier, AsString)
         "Name: \n"\
         "Owner: \n"\
         "Version: tip\n"\
-        "Unique name: fuel.ignitionrobotics.org//worlds/\n"
+        "Unique name: fuel.ignitionrobotics.org/worlds/\n"
         "Local path: \n"
         "Server:\n"
         "  URL: https://fuel.ignitionrobotics.org\n"
@@ -131,7 +131,7 @@ TEST(WorldIdentifier, AsString)
         "Name: \n"\
         "Owner: \n"\
         "Version: tip\n"\
-        "Unique name: fuel.ignitionrobotics.org\\worlds\n"
+        "Unique name: fuel.ignitionrobotics.org/worlds\n"
         "Local path: \n"
         "Server:\n"
         "  URL: https://fuel.ignitionrobotics.org\n"

--- a/src/WorldIter.cc
+++ b/src/WorldIter.cc
@@ -228,6 +228,12 @@ WorldIdentifier *WorldIter::operator->()
 }
 
 //////////////////////////////////////////////////
+WorldIdentifier &WorldIter::operator*()
+{
+  return this->dataPtr->worldId;
+}
+
+//////////////////////////////////////////////////
 WorldIter::operator WorldIdentifier() const
 {
   return this->dataPtr->worldId;

--- a/src/cmd/cmdfuel.rb.in
+++ b/src/cmd/cmdfuel.rb.in
@@ -444,7 +444,8 @@ class Cmd
       when 'update'
         Importer.extern 'int update(const char *, const char *)'
         if not Importer.update(options['onlymodels'],
-                               options['onlyworlds'])
+                               options['onlyworlds'],
+                               options['header'])
           exit(-1)
         end
       end

--- a/src/cmd/cmdfuel.rb.in
+++ b/src/cmd/cmdfuel.rb.in
@@ -89,7 +89,7 @@ SUBCOMMANDS = {
   "                           the model. If unspecified, the server will be\n"\
   "                           https://fuel.ignitionrobotics.org.           \n"\
   "  --header arg             Set an HTTP header, such as                  \n"\
-  "                           --header 'authorization: Bearer JWT'.        \n" +
+  "                           --header 'Private-Token: <access_token>'.    \n" +
   COMMON_OPTIONS,
 
  'download' =>
@@ -101,7 +101,7 @@ SUBCOMMANDS = {
   "  -u [--url] arg           Full resource URL, such as:                  \n"\
   "                           https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Ambulance\n"\
   "  --header arg             Set an HTTP header, such as                  \n"\
-  "                           --header 'authorization: Bearer JWT'.        \n"\
+  "                           --header 'Private-Token: <access_token>'.    \n"\
   "  -j [--jobs] arg          Number of parallel downloads (default: 1,    \n"\
   "                           max: #{MAX_PARALLEL_JOBS}). \n"\
   "  -t [--type] arg          Limit what resource type (i.e. model, world) \n"\
@@ -123,7 +123,7 @@ SUBCOMMANDS = {
   "  -p [--private]           Use this argument to make the model private. \n"\
   "  -b [--public]            Use this argument to make the model public.  \n"\
   "  --header arg             Set an HTTP header, such as                  \n"\
-  "                           --header 'authorization: Bearer JWT'.        \n" +
+  "                           --header 'Private-Token: <access_token>'.    \n" +
   COMMON_OPTIONS,
 
   'list' =>
@@ -150,7 +150,6 @@ SUBCOMMANDS = {
   "                           metadata.pbtxt.                              \n"+
   "  --pbtxt2config arg       Convert a metadata.pbtxt file to a           \n"\
   "                           model.confg.                                 \n"+
-
   COMMON_OPTIONS,
 
  'upload' =>
@@ -173,6 +172,7 @@ SUBCOMMANDS = {
   "  --header arg             Set an HTTP header, such as                  \n"\
   "                           --header 'Private-Token: <access_token>'.    \n" +
   COMMON_OPTIONS,
+
  'update' =>
   "Update all models and worlds in local cache                             \n"\
   "                                                                        \n"\
@@ -182,8 +182,8 @@ SUBCOMMANDS = {
   "  --onlymodels             Use this argument to only update models.     \n"\
   "  --onlyworlds             Use this argument to only update worlds.     \n"\
   "  --header arg             Set an HTTP header, such as                  \n"\
-  "                           --header 'authorization: Bearer JWT'.        \n" +
-   COMMON_OPTIONS,
+  "                           --header 'Private-Token: <access_token>'.    \n" +
+  COMMON_OPTIONS
 }
 
 #

--- a/src/cmd/cmdfuel.rb.in
+++ b/src/cmd/cmdfuel.rb.in
@@ -173,6 +173,16 @@ SUBCOMMANDS = {
   "  --header arg             Set an HTTP header, such as                  \n"\
   "                           --header 'Private-Token: <access_token>'.    \n" +
   COMMON_OPTIONS,
+  'update' =>
+   "Update all models in local cache                                       \n"\
+   "                                                                       \n"\
+   "  ign fuel update [options]                                            \n"\
+   "                                                                       \n"\
+   "Available Options:                                                     \n"\
+   "  --onlymodels            Use this argument to only update models.     \n"\
+   "  --onlyworlds            Use this argument to only update worlds.     \n"\
+   "                          If not option selected, both get updated.    \n" +
+   COMMON_OPTIONS,
 }
 
 #
@@ -194,7 +204,9 @@ class Cmd
       'model' => '',
       'config2pbtxt' => '',
       'pbtxt2config' => '',
-      'private' => ''
+      'private' => '',
+      'onlymodels' => '',
+      'onlyworlds' => ''
     }
 
     usage = COMMANDS[args[0]]
@@ -255,6 +267,12 @@ class Cmd
       end
       opts.on('-j [JOBS]', '--jobs', String, 'Number of parallel downloads') do |jobs|
         options['jobs'] = jobs || 1
+      end
+      opts.on('--onlymodels', 'Only update models') do
+        options['onlymodels'] = 'true'
+      end
+      opts.on('--onlyworlds', 'Only update worlds') do
+        options['onlyworlds'] = 'true'
       end
     end # opt_parser do
 
@@ -420,6 +438,12 @@ class Cmd
                                options['header'],
                                options['private'],
                                options['owner'])
+          exit(-1)
+        end
+      when 'update'
+        Importer.extern 'int update(const char *, const char *)'
+        if not Importer.update(options['onlymodels'],
+                               options['onlyworlds'])
           exit(-1)
         end
       end

--- a/src/cmd/cmdfuel.rb.in
+++ b/src/cmd/cmdfuel.rb.in
@@ -173,15 +173,16 @@ SUBCOMMANDS = {
   "  --header arg             Set an HTTP header, such as                  \n"\
   "                           --header 'Private-Token: <access_token>'.    \n" +
   COMMON_OPTIONS,
-  'update' =>
-   "Update all models in local cache                                       \n"\
-   "                                                                       \n"\
-   "  ign fuel update [options]                                            \n"\
-   "                                                                       \n"\
-   "Available Options:                                                     \n"\
-   "  --onlymodels            Use this argument to only update models.     \n"\
-   "  --onlyworlds            Use this argument to only update worlds.     \n"\
-   "                          If not option selected, both get updated.    \n" +
+ 'update' =>
+  "Update all models and worlds in local cache                             \n"\
+  "                                                                        \n"\
+  "  ign fuel update [options]                                             \n"\
+  "                                                                        \n"\
+  "Available Options:                                                      \n"\
+  "  --onlymodels             Use this argument to only update models.     \n"\
+  "  --onlyworlds             Use this argument to only update worlds.     \n"\
+  "  --header arg             Set an HTTP header, such as                  \n"\
+  "                           --header 'authorization: Bearer JWT'.        \n" +
    COMMON_OPTIONS,
 }
 

--- a/src/cmd/cmdfuel.rb.in
+++ b/src/cmd/cmdfuel.rb.in
@@ -67,6 +67,7 @@ COMMANDS = { 'fuel' =>
   "  list                     List available resources                     \n"\
   "  meta                     Read and write resource metadata             \n"\
   "  upload                   Upload resources                             \n"\
+  "  update                   Update resources                             \n"\
   "                                                                        \n"\
   "Available Options:                                                      \n"\
   "  -v [ --verbose ] [arg]   Adjust the level of console output (0~4).    \n"\
@@ -206,8 +207,8 @@ class Cmd
       'config2pbtxt' => '',
       'pbtxt2config' => '',
       'private' => '',
-      'onlymodels' => '',
-      'onlyworlds' => ''
+      'onlymodels' => '0',
+      'onlyworlds' => '0'
     }
 
     usage = COMMANDS[args[0]]
@@ -270,10 +271,10 @@ class Cmd
         options['jobs'] = jobs || 1
       end
       opts.on('--onlymodels', 'Only update models') do
-        options['onlymodels'] = 'true'
+        options['onlymodels'] = '1'
       end
       opts.on('--onlyworlds', 'Only update worlds') do
-        options['onlyworlds'] = 'true'
+        options['onlyworlds'] = '1'
       end
     end # opt_parser do
 
@@ -442,7 +443,7 @@ class Cmd
           exit(-1)
         end
       when 'update'
-        Importer.extern 'int update(const char *, const char *)'
+        Importer.extern 'int update(const char *, const char *, const char *)'
         if not Importer.update(options['onlymodels'],
                                options['onlyworlds'],
                                options['header'])

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -979,7 +979,7 @@ extern "C" IGNITION_FUEL_TOOLS_VISIBLE int editUrl(
 }
 
 extern "C" IGNITION_FUEL_TOOLS_VISIBLE int update(
-    const char *_onlyModels, const char *_onlyWorlds)
+    const char *_onlyModels, const char *_onlyWorlds, const char *_header)
 {
   std::cout << "Updating fuel cache" << std::endl;
   // Add signal handler for SIGTERM and SIGINT. Ctrl-C doesn't work without this
@@ -1008,10 +1008,21 @@ extern "C" IGNITION_FUEL_TOOLS_VISIBLE int update(
   conf.SetUserAgent("FuelTools " IGNITION_FUEL_TOOLS_VERSION_FULL);
 
   ignition::fuel_tools::FuelClient client(conf);
-  if (!onlyWorldsBool && !client.UpdateModels()) {
+
+  // Headers
+  std::vector<std::string> headers;
+  if (_header && strlen(_header) > 0)
+  {
+    headers.push_back(_header);
+  }
+  else
+  {
+    headers = {};
+  }
+  if (!onlyWorldsBool && !client.UpdateModels(headers)) {
     return 0;
   }
-  if (!onlyModelsBool && !client.UpdateWorlds()) {
+  if (!onlyModelsBool && !client.UpdateWorlds(headers)) {
     return 0;
   }
   return 1;

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -978,6 +978,7 @@ extern "C" IGNITION_FUEL_TOOLS_VISIBLE int editUrl(
   return 1;
 }
 
+//////////////////////////////////////////////////
 extern "C" IGNITION_FUEL_TOOLS_VISIBLE int update(
     const char *_onlyModels, const char *_onlyWorlds, const char *_header)
 {
@@ -994,12 +995,14 @@ extern "C" IGNITION_FUEL_TOOLS_VISIBLE int update(
   bool onlyModelsBool = false;
   if (_onlyModels && std::strlen(_onlyModels) != 0)
   {
-    onlyModelsBool = true;
+    std::string str = ignition::common::lowercase(_onlyModels);
+    onlyModelsBool = str == "1" || str == "true";
   }
   bool onlyWorldsBool = false;
   if (_onlyWorlds && std::strlen(_onlyWorlds) != 0)
   {
-    onlyWorldsBool = true;
+    std::string str = ignition::common::lowercase(_onlyWorlds);
+    onlyWorldsBool = str == "1" || str == "true";
   }
   // Client
   ignition::fuel_tools::ClientConfig conf;
@@ -1011,13 +1014,8 @@ extern "C" IGNITION_FUEL_TOOLS_VISIBLE int update(
   // Headers
   std::vector<std::string> headers;
   if (_header && strlen(_header) > 0)
-  {
     headers.push_back(_header);
-  }
-  else
-  {
-    headers = {};
-  }
+
   if (!onlyWorldsBool && !client.UpdateModels(headers)) {
     return 0;
   }

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -981,7 +981,6 @@ extern "C" IGNITION_FUEL_TOOLS_VISIBLE int editUrl(
 extern "C" IGNITION_FUEL_TOOLS_VISIBLE int update(
     const char *_onlyModels, const char *_onlyWorlds, const char *_header)
 {
-  std::cout << "Updating fuel cache" << std::endl;
   // Add signal handler for SIGTERM and SIGINT. Ctrl-C doesn't work without this
   // handler.
   ignition::common::SignalHandler sigHandler;

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -977,3 +977,42 @@ extern "C" IGNITION_FUEL_TOOLS_VISIBLE int editUrl(
 
   return 1;
 }
+
+extern "C" IGNITION_FUEL_TOOLS_VISIBLE int update(
+    const char *_onlyModels, const char *_onlyWorlds)
+{
+  std::cout << "Updating fuel cache" << std::endl;
+  // Add signal handler for SIGTERM and SIGINT. Ctrl-C doesn't work without this
+  // handler.
+  ignition::common::SignalHandler sigHandler;
+  sigHandler.AddCallback([&](int _sig) {
+      if (SIGTERM == _sig || SIGINT == _sig)
+      {
+        std::exit(1);
+      }
+  });
+
+  bool onlyModelsBool = false;
+  if (_onlyModels && std::strlen(_onlyModels) != 0)
+  {
+    onlyModelsBool = true;
+  }
+  bool onlyWorldsBool = false;
+  if (_onlyWorlds && std::strlen(_onlyWorlds) != 0)
+  {
+    onlyWorldsBool = true;
+  }
+  // Client
+  ignition::fuel_tools::ClientConfig conf;
+
+  conf.SetUserAgent("FuelTools " IGNITION_FUEL_TOOLS_VERSION_FULL);
+
+  ignition::fuel_tools::FuelClient client(conf);
+  if (!onlyWorldsBool && !client.UpdateModels()) {
+    return 0;
+  }
+  if (!onlyModelsBool && !client.UpdateWorlds()) {
+    return 0;
+  }
+  return 1;
+}

--- a/src/ign.hh
+++ b/src/ign.hh
@@ -128,6 +128,7 @@ extern "C" IGNITION_FUEL_TOOLS_VISIBLE int editUrl(
     const char *_path = nullptr);
 
 /// \brief TODO
-extern "C" IGNITION_FUEL_TOOLS_VISIBLE int update();
+extern "C" IGNITION_FUEL_TOOLS_VISIBLE int update(
+    const char *_onlyModels, const char *_onlyWorlds);
 
 #endif

--- a/src/ign.hh
+++ b/src/ign.hh
@@ -128,6 +128,6 @@ extern "C" IGNITION_FUEL_TOOLS_VISIBLE int editUrl(
     const char *_path = nullptr);
 
 /// \brief TODO
-extern "C" IGNITION_FUEL_TOOLS_VISIBLE int updateModels();
+extern "C" IGNITION_FUEL_TOOLS_VISIBLE int update();
 
 #endif

--- a/src/ign.hh
+++ b/src/ign.hh
@@ -135,6 +135,7 @@ extern "C" IGNITION_FUEL_TOOLS_VISIBLE int editUrl(
 /// \param[in] _header An HTTP header.
 /// \return 1 if successful, 0 if not.
 extern "C" IGNITION_FUEL_TOOLS_VISIBLE int update(
-    const char *_onlyModels, const char *_onlyWorlds, const char *_header);
+    const char *_onlyModels = nullptr, const char *_onlyWorlds = nullptr,
+    const char *_header = nullptr);
 
 #endif

--- a/src/ign.hh
+++ b/src/ign.hh
@@ -127,8 +127,14 @@ extern "C" IGNITION_FUEL_TOOLS_VISIBLE int editUrl(
     const char *_private = nullptr,
     const char *_path = nullptr);
 
-/// \brief TODO
+/// \brief External hook to execute 'ign fuel update [options] from the command'
+/// line
+///
+/// \param[in] _onlyModels "1" to only update models.
+/// \param[in] _onlyWorlds "1" to only update worlds.
+/// \param[in] _header An HTTP header.
+/// \return 1 if successful, 0 if not.
 extern "C" IGNITION_FUEL_TOOLS_VISIBLE int update(
-    const char *_onlyModels, const char *_onlyWorlds);
+    const char *_onlyModels, const char *_onlyWorlds, const char *_header);
 
 #endif

--- a/src/ign.hh
+++ b/src/ign.hh
@@ -127,4 +127,7 @@ extern "C" IGNITION_FUEL_TOOLS_VISIBLE int editUrl(
     const char *_private = nullptr,
     const char *_path = nullptr);
 
+/// \brief TODO
+extern "C" IGNITION_FUEL_TOOLS_VISIBLE int updateModels();
+
 #endif


### PR DESCRIPTION
Signed-off-by: Tomas Lorente <jtlorente@ekumenlabs.com>

# 🎉 New feature

Update command for fuel

## Summary

`ign fuel update`, supports --onlymodels and --onlyworlds to select if you only want to download one of those. By default downloads both.

## Test it

Download a model or a world, modify that one in fuel to up the version, call the command and see it update.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**