### PR TITLE
Detect ign instead of using cmake module to check for ignition-tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,10 +62,7 @@ set(IGN_MSGS_MAJOR_VER ${ignition-msgs6_VERSION_MAJOR})
 
 #--------------------------------------
 # Find ignition-tools
-ign_find_package(ignition-tools QUIET)
-if (ignition-tools_FOUND)
-  set (HAVE_IGN_TOOLS TRUE)
-endif()
+find_program(HAVE_IGN_TOOLS ign)
 
 #============================================================================
 # Configure the build


### PR DESCRIPTION
Part of https://github.com/ignition-tooling/release-tools/issues/472

I don't detect the conditional installation of the `ign` submodule, the PR just
changed the way of detecting ign for testing.
