### PR TITLE
APIs for retrieving models in parallel

### DIFF
--- a/include/ignition/fuel_tools/FuelClient.hh
+++ b/include/ignition/fuel_tools/FuelClient.hh
@@ -260,6 +260,13 @@ namespace ignition
                   const std::vector<WorldIdentifier> &_ids,
                   size_t _jobs = 2);
 
+      using ModelResult = std::tuple<ModelIdentifier, Result>;
+
+      public: std::vector<ModelResult> DownloadModelsNew(
+                  const std::vector<ModelIdentifier> &_ids,
+                  size_t _jobs = 2);
+
+
       /// \brief Check if a model is already present in the local cache.
       /// \param[in] _modelUrl The unique URL of the model on a Fuel server.
       /// E.g.: https://fuel.ignitionrobotics.org/1.0/caguero/models/Beer

--- a/include/ignition/fuel_tools/FuelClient.hh
+++ b/include/ignition/fuel_tools/FuelClient.hh
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <string>
+#include <tuple>
 #include <vector>
 #include <ignition/common/URI.hh>
 
@@ -252,20 +253,27 @@ namespace ignition
       public: Result DownloadWorld(const common::URI &_worldUrl,
                                    std::string &_path);
 
-      public: Result DownloadModels(
+      using ModelResult = std::tuple<ModelIdentifier, Result>;
+
+      /// \brief Download a list of models from ignition fuel.
+      /// \param[in] _ids The list of model ids to download.
+      ///   This will also find all recursive dependencies of the models
+      /// \param[in] _jobs Number of parallel jobs to use to download models
+      /// \return Result of the download operation.
+      //    The resulting vector will be at least the size of the _ids input
+      //    vector, but may be larger depending on the number of depedencies
+      //    downloaded
+      public: std::vector<ModelResult> DownloadModels(
                   const std::vector<ModelIdentifier> &_ids,
                   size_t _jobs = 2);
 
+      /// \brief Download a list of mworlds from ignition fuel.
+      /// \param[in] _ids The list of world ids to download.
+      /// \param[in] _jobs Number of parallel jobs to use to download worlds.
+      /// \return Result of the download operation.
       public: Result DownloadWorlds(
                   const std::vector<WorldIdentifier> &_ids,
                   size_t _jobs = 2);
-
-      using ModelResult = std::tuple<ModelIdentifier, Result>;
-
-      public: std::vector<ModelResult> DownloadModelsNew(
-                  const std::vector<ModelIdentifier> &_ids,
-                  size_t _jobs = 2);
-
 
       /// \brief Check if a model is already present in the local cache.
       /// \param[in] _modelUrl The unique URL of the model on a Fuel server.

--- a/include/ignition/fuel_tools/FuelClient.hh
+++ b/include/ignition/fuel_tools/FuelClient.hh
@@ -203,6 +203,27 @@ namespace ignition
       public: Result DownloadModel(const ModelIdentifier &_id,
                   const std::vector<std::string> &_headers);
 
+      /// \brief Download a model from ignition fuel. This will override an
+      /// existing local copy of the model.
+      /// \param[in] _id The model identifier.
+      /// \param[in] _headers Headers to set on the HTTP request.
+      /// \param[out] _dependencies List of models that this model depends on.
+      /// \return Result of the download operation
+      public: Result DownloadModel(const ModelIdentifier &_id,
+                  const std::vector<std::string> &_headers,
+                  std::vector<ModelIdentifier> &_dependencies);
+
+      public: Result DownloadModels(
+                  const std::vector<ModelIdentifier> &_ids,
+                  size_t _jobs = 2);
+
+      /// \brief Retrieve the list of dependencies for a model. 
+      /// \param[in] _id The model identifier.
+      /// \param[out] _dependencies The list of dependencies.
+      /// \return Result of the operation
+      public: Result ModelDependencies(const ModelIdentifier &_id,
+                  std::vector<ModelIdentifier> &_dependencies);
+
       /// \brief Download a world from Ignition Fuel. This will override an
       /// existing local copy of the world.
       /// \param[out] _id The world identifier, with local path updated.

--- a/include/ignition/fuel_tools/FuelClient.hh
+++ b/include/ignition/fuel_tools/FuelClient.hh
@@ -213,15 +213,19 @@ namespace ignition
                   const std::vector<std::string> &_headers,
                   std::vector<ModelIdentifier> &_dependencies);
 
-      public: Result DownloadModels(
-                  const std::vector<ModelIdentifier> &_ids,
-                  size_t _jobs = 2);
-
       /// \brief Retrieve the list of dependencies for a model.
       /// \param[in] _id The model identifier.
       /// \param[out] _dependencies The list of dependencies.
       /// \return Result of the operation
       public: Result ModelDependencies(const ModelIdentifier &_id,
+                  std::vector<ModelIdentifier> &_dependencies);
+
+      /// \brief Retrieve the list of dependencies for a list of models.
+      /// \param[in] _id The list of model identifiers.
+      /// \param[out] _dependencies The list of dependencies.
+      /// \return Result of the operation
+      public: Result ModelDependencies(
+                  const std::vector<ModelIdentifier> &_id,
                   std::vector<ModelIdentifier> &_dependencies);
 
       /// \brief Download a world from Ignition Fuel. This will override an
@@ -247,6 +251,14 @@ namespace ignition
       /// \return Result of the download operation.
       public: Result DownloadWorld(const common::URI &_worldUrl,
                                    std::string &_path);
+
+      public: Result DownloadModels(
+                  const std::vector<ModelIdentifier> &_ids,
+                  size_t _jobs = 2);
+
+      public: Result DownloadWorlds(
+                  const std::vector<WorldIdentifier> &_ids,
+                  size_t _jobs = 2);
 
       /// \brief Check if a model is already present in the local cache.
       /// \param[in] _modelUrl The unique URL of the model on a Fuel server.

--- a/include/ignition/fuel_tools/FuelClient.hh
+++ b/include/ignition/fuel_tools/FuelClient.hh
@@ -217,7 +217,7 @@ namespace ignition
                   const std::vector<ModelIdentifier> &_ids,
                   size_t _jobs = 2);
 
-      /// \brief Retrieve the list of dependencies for a model. 
+      /// \brief Retrieve the list of dependencies for a model.
       /// \param[in] _id The model identifier.
       /// \param[out] _dependencies The list of dependencies.
       /// \return Result of the operation

--- a/src/ClientConfig_TEST.cc
+++ b/src/ClientConfig_TEST.cc
@@ -64,7 +64,6 @@ std::string homePath()
 /// \ToDo: Move this function to ignition::common::Filesystem
 std::string cachePath()
 {
-  std::string cachePath;
 #ifndef _WIN32
   return std::string("/tmp/ignition/fuel");
 #else

--- a/src/FuelClient.cc
+++ b/src/FuelClient.cc
@@ -699,8 +699,18 @@ Result FuelClient::ModelDependencies(const ModelIdentifier &_id,
         ignition::common::URI dependencyURI(meta.dependencies(i).uri());
 
         ModelIdentifier dependencyID;
-        this->ParseModelUrl(dependencyURI, dependencyID);
-        _dependencies.push_back(dependencyID);
+        if(!this->ParseModelUrl(dependencyURI, dependencyID))
+        {
+          // There is a potential that depdencies are specified via
+          // [model://model_name], which is valid, but not something that we
+          // can fetch from Fuel. In that case, warn the user so they have
+          // a chance to update their specified dependencies.
+          ignwarn << "Error resolving URL for dependency [" <<
+            meta.dependencies(i).uri() << "] of model [" <<
+            _id.UniqueName() <<"]: Skipping" << std::endl;
+        } else {
+          _dependencies.push_back(dependencyID);
+        }
       }
     }
   }

--- a/src/FuelClient.cc
+++ b/src/FuelClient.cc
@@ -571,7 +571,7 @@ Result FuelClient::DownloadModel(const ModelIdentifier &_id,
   if(!res)
     return res;
 
-  for (auto dep: dependencies)
+  for (auto dep : dependencies)
   {
     auto dep_res = this->DownloadModel(dep, _headers);
 
@@ -648,7 +648,7 @@ Result FuelClient::DownloadModel(const ModelIdentifier &_id,
   if (!this->dataPtr->cache->SaveModel(newId, resp.data, true))
     return Result(ResultType::FETCH_ERROR);
 
-  return this->ModelDependencies(_id, _dependencies); 
+  return this->ModelDependencies(_id, _dependencies);
 }
 
 //////////////////////////////////////////////////

--- a/src/FuelClient.cc
+++ b/src/FuelClient.cc
@@ -695,7 +695,6 @@ Result FuelClient::ModelDependencies(const ModelIdentifier &_id,
 
       for (int i = 0; i < meta.dependencies_size(); ++i)
       {
-        std::string dependencyPath;
         ignition::common::URI dependencyURI(meta.dependencies(i).uri());
 
         ModelIdentifier dependencyID;
@@ -881,6 +880,7 @@ std::vector<FuelClient::ModelResult> FuelClient::DownloadModels(
           if (uniqueIds.count(dep) == 0)
           {
             idsToDownload.push_back(dep);
+            uniqueIds.insert(dep);
           }
         }
       }

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -632,13 +632,14 @@ extern "C" IGNITION_FUEL_TOOLS_VISIBLE int downloadUrl(const char *_url,
 
     if (downloadModels)
     {
-      auto result = client.DownloadModelsNew(modelIds, _jobs);
+      auto result = client.DownloadModels(modelIds, _jobs);
     }
 
     if (downloadWorlds)
     {
       auto result = client.DownloadWorlds(worldIds, _jobs);
-      ignerr << "Failed to download worlds for collection [" << collection.Name()
+      ignerr << "Failed to download worlds for collection ["
+          << collection.Name()
           << "]" << std::endl;
     }
   }

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -632,13 +632,7 @@ extern "C" IGNITION_FUEL_TOOLS_VISIBLE int downloadUrl(const char *_url,
 
     if (downloadModels)
     {
-      auto result = client.DownloadModels(modelIds, _jobs);
-      if (!result)
-      {
-        ignerr << "Failed to download models for collection [" << collection.Name()
-          << "]" << std::endl;
-        return false;
-      }
+      auto result = client.DownloadModelsNew(modelIds, _jobs);
     }
 
     if (downloadWorlds)

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -630,93 +630,22 @@ extern "C" IGNITION_FUEL_TOOLS_VISIBLE int downloadUrl(const char *_url,
       return false;
     }
 
-    size_t jobs = std::max(1, _jobs);
-
-    ignmsg << "Using " << jobs << " jobs to download collection of "
-           << totalItemCount << " items" << std::endl;
-
-    std::deque<std::future<ignition::fuel_tools::Result>> tasks;
-
-    // Check for finished tasks by checking if the status of their futures is
-    // "ready". If a task is finished, check if it succeeded and print out an
-    // error message if it failed. When a task is finished, it gets erased from
-    // the tasks list to make room for other tasks to be added.
-    size_t itemCount = 0;
-    auto checkForFinishedTasks = [&itemCount, &totalItemCount, &tasks] {
-      auto finishedIt =
-          std::partition(tasks.begin(), tasks.end(), [](const auto &_task)
-              {
-                return std::future_status::ready !=
-                _task.wait_for(std::chrono::milliseconds(100));
-              });
-
-      if (finishedIt != tasks.end())
-      {
-        for (auto taskIt = finishedIt; taskIt != tasks.end(); ++taskIt)
-        {
-          ignition::fuel_tools::Result result = taskIt->get();
-          if (result)
-          {
-            ++itemCount;
-          }
-          else
-          {
-            ignerr << result.ReadableResult() << std::endl;
-          }
-        }
-
-        tasks.erase(finishedIt, tasks.end());
-        ignmsg << "Downloaded: " << itemCount << " / " << totalItemCount
-               << std::endl;
-      }
-    };
-
-    // Here we use std::async to download items in parallel. The download task
-    // is started asynchronously and gets added to the task list which is
-    // monitored for completion.
     if (downloadModels)
     {
-      for (const auto &modelId : modelIds)
+      auto result = client.DownloadModels(modelIds, _jobs);
+      if (!result)
       {
-        // Check if any of the tasks are done. Don't start a new task until the
-        // number of tasks in the tasks lists is below the number of jobs
-        // specified by the user.
-        while (tasks.size() >= jobs)
-        {
-          checkForFinishedTasks();
-        }
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-        auto handle = std::async(std::launch::async, [&modelId, &client]
-            {
-              return client.DownloadModel(modelId);
-            });
-        tasks.push_back(std::move(handle));
+        ignerr << "Failed to download models for collection [" << collection.Name()
+          << "]" << std::endl;
+        return false;
       }
     }
 
     if (downloadWorlds)
     {
-      // We need a mutable worldId because DownloadWorld modifies it
-      for (auto &worldId : worldIds)
-      {
-        // Check if any of the tasks are done
-        while (tasks.size() >= jobs)
-        {
-          checkForFinishedTasks();
-        }
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-        auto handle = std::async(std::launch::async, [&worldId, &client]
-            {
-            return client.DownloadWorld(worldId);
-            });
-        tasks.push_back(std::move(handle));
-      }
-    }
-
-    // All the tasks have been queued. Now wait for them to finish
-    while (!tasks.empty())
-    {
-      checkForFinishedTasks();
+      auto result = client.DownloadWorlds(worldIds, _jobs);
+      ignerr << "Failed to download worlds for collection [" << collection.Name()
+          << "]" << std::endl;
     }
   }
   else


### PR DESCRIPTION
# 🎉 New feature

Closes #188 

## Summary

Adds APIs for downloading a set of models in parallel.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**