### PR TITLE
Use a pretty name for IgnCURL to make error messages less confusing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ ign_find_package(TINYXML2 REQUIRED PRIVATE PRETTY tinyxml2)
 
 #--------------------------------------
 # Find libcurl
-ign_find_package(IgnCURL REQUIRED PRIVATE)
+ign_find_package(IgnCURL REQUIRED PRIVATE PRETTY curl)
 
 #--------------------------------------
 # Find jsoncpp


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
The error message users get when curl is missing from the system is that `IgnCURL` is missing, which can be confusing.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
