### PR TITLE
Fix windows warning for exception c++ code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,11 @@ if (ignition-tools_FOUND)
   set (HAVE_IGN_TOOLS TRUE)
 endif()
 
+# Windows Required option to build c++ code dealing with std exception handling
+if(MSVC)
+  set (CMAKE_CXX_FLAGS "/EHsc")
+endif(MSVC)
+
 #============================================================================
 # Configure the build
 #============================================================================


### PR DESCRIPTION
Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>

# 🦟 Bug fix

Fixes #211

## Summary
Include the missing flag for Windows builds. This will be forward ported up to ign-fuel-tools-7

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**