### PR TITLE
FuelClient.cc: include <deque>

### DIFF
--- a/src/FuelClient.cc
+++ b/src/FuelClient.cc
@@ -25,6 +25,7 @@
 #endif
 
 #include <algorithm>
+#include <deque>
 #include <iomanip>
 #include <iostream>
 #include <memory>

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -638,9 +638,6 @@ extern "C" IGNITION_FUEL_TOOLS_VISIBLE int downloadUrl(const char *_url,
     if (downloadWorlds)
     {
       auto result = client.DownloadWorlds(worldIds, _jobs);
-      ignerr << "Failed to download worlds for collection ["
-          << collection.Name()
-          << "]" << std::endl;
     }
   }
   else

--- a/src/ign_src_TEST.cc
+++ b/src/ign_src_TEST.cc
@@ -492,7 +492,8 @@ TEST_P(DownloadCollectionTest, AllItems)
   // Check output
   EXPECT_NE(stdOutBuffer.str().find("Download succeeded"), std::string::npos)
       << stdOutBuffer.str();
-  EXPECT_TRUE(stdErrBuffer.str().empty());
+  EXPECT_TRUE(stdErrBuffer.str().empty())
+      << stdErrBuffer.str();
 
   // Check files
   // Model: Backpack

--- a/src/ign_src_TEST.cc
+++ b/src/ign_src_TEST.cc
@@ -630,7 +630,8 @@ TEST_P(DownloadCollectionTest, Worlds)
   // Check output
   EXPECT_NE(stdOutBuffer.str().find("Download succeeded"), std::string::npos)
       << stdOutBuffer.str();
-  EXPECT_TRUE(stdErrBuffer.str().empty());
+  EXPECT_TRUE(stdErrBuffer.str().empty())
+      << stdErrBuffer.str();
 
   // Check files
   // Model: Backpack


### PR DESCRIPTION
# 🦟 Bug fix

Fixes the Windows build.

## Summary

The `std::deque` datatype was used in #199, but the Windows compiler seems to have trouble identifying the datatype. Seems like a missing header.

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_fuel-tools-ign-4-win&build=8)](https://build.osrfoundation.org/job/ign_fuel-tools-ign-4-win/8/) https://build.osrfoundation.org/job/ign_fuel-tools-ign-4-win/8/

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
