### PR TITLE
Fix cmdfuel ruby script generation on Windows with MSVC

### DIFF
--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -3,6 +3,8 @@
 # Ex: cmdfuel0.rb
 if (APPLE)
   set(IGN_LIBRARY_NAME lib${PROJECT_NAME_LOWER}.dylib)
+elseif(MSVC)
+  set(IGN_LIBRARY_NAME ${PROJECT_NAME_LOWER}.dll)
 else()
   set(IGN_LIBRARY_NAME lib${PROJECT_NAME_LOWER}.so)
 endif()


### PR DESCRIPTION
# 🦟 Bug fix

Fix cmdfuel ruby script generation on Windows with MSVC

## Summary

Before this script, when running commands like `ign fuel download` on Windows failed with:
~~~
(igngazebo) C:\Users\STraversaro>ign fuel download -v --url https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Ambulance
Library error: ignition-tools-backward.dll not found. Improved backtrace generation will be disabled
Library error: [libignition-fuel_tools7.so] not found.
~~~

After this fix:
~~~
(igngazebo) C:\Users\STraversaro>ign fuel download -v --url https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Ambulance
Library error: ignition-tools-backward.dll not found. Improved backtrace generation will be disabled
Library error: [libignition-fuel_tools7.so] not found.
~~~

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
