### PR TITLE
Move test cache to build folder

### DIFF
--- a/src/ign_src_TEST.cc
+++ b/src/ign_src_TEST.cc
@@ -20,7 +20,6 @@
 #include <stdlib.h>
 
 #include <string>
-#include <ignition/common/Console.hh>
 #include <ignition/common/Filesystem.hh>
 #include <ignition/utilities/ExtraTestMacros.hh>
 
@@ -69,7 +68,10 @@ class CmdLine : public ::testing::Test
     std::cerr.rdbuf(g_stdErrFile);
   }
 
+  /// \brief Buffer for std::cout
   public: std::stringstream stdOutBuffer;
+
+  /// \brief Buffer for std::cerr
   public: std::stringstream stdErrBuffer;
 
   /// \brief Path for a test cache within the build folder
@@ -204,7 +206,7 @@ TEST_F(CmdLine, DownloadConfigCache)
 
   // Test config
   std::ofstream ofs;
-  std::string testPath = common::joinPaths(this->testCachePath, "test_conf.yaml");
+  auto testPath = common::joinPaths(this->testCachePath, "test_conf.yaml");
   ofs.open(testPath, std::ofstream::out | std::ofstream::app);
 
   ofs << "---"                                    << std::endl
@@ -376,8 +378,8 @@ TEST_P(DownloadCollectionTest, AllItems)
                   nullptr, nullptr, nullptr, GetParam()));
 
   // Check output
-  EXPECT_NE(this->stdOutBuffer.str().find("Download succeeded"), std::string::npos)
-      << this->stdOutBuffer.str();
+  EXPECT_NE(this->stdOutBuffer.str().find("Download succeeded"),
+      std::string::npos) << this->stdOutBuffer.str();
   EXPECT_TRUE(this->stdErrBuffer.str().empty()) << this->stdErrBuffer.str();
 
   // Check files
@@ -439,8 +441,8 @@ TEST_P(DownloadCollectionTest, Models)
                   nullptr, nullptr, "model", GetParam()));
 
   // Check output
-  EXPECT_NE(this->stdOutBuffer.str().find("Download succeeded"), std::string::npos)
-      << this->stdOutBuffer.str();
+  EXPECT_NE(this->stdOutBuffer.str().find("Download succeeded"),
+      std::string::npos) << this->stdOutBuffer.str();
   EXPECT_TRUE(this->stdErrBuffer.str().empty()) << this->stdErrBuffer.str();
 
   // Check files
@@ -490,8 +492,8 @@ TEST_P(DownloadCollectionTest, Worlds)
                   nullptr, nullptr, "world", GetParam()));
 
   // Check output
-  EXPECT_NE(this->stdOutBuffer.str().find("Download succeeded"), std::string::npos)
-      << this->stdOutBuffer.str();
+  EXPECT_NE(this->stdOutBuffer.str().find("Download succeeded"),
+      std::string::npos) << this->stdOutBuffer.str();
   EXPECT_TRUE(this->stdErrBuffer.str().empty()) << this->stdErrBuffer.str();
 
   // Check files

--- a/src/ign_src_TEST.cc
+++ b/src/ign_src_TEST.cc
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 
 #include <string>
+#include <ignition/common/Console.hh>
 #include <ignition/common/Filesystem.hh>
 #include <ignition/utilities/ExtraTestMacros.hh>
 
@@ -33,220 +34,177 @@ static std::streambuf *g_stdOutFile;
 static std::streambuf *g_stdErrFile;
 
 /////////////////////////////////////////////////
-// \brief Redirect stdout and stderr to streams.
-void redirectIO(std::stringstream &_stdOutBuffer,
-                std::stringstream &_stdErrBuffer)
+class CmdLine : public ::testing::Test
 {
-  g_stdOutFile = std::cout.rdbuf(_stdOutBuffer.rdbuf());
-  g_stdErrFile = std::cerr.rdbuf(_stdErrBuffer.rdbuf());
-}
+  // Documentation inherited
+  public: void SetUp() override
+  {
+    cmdVerbosity("4");
+
+    // Redirect stdout and stderr to streams.
+    g_stdOutFile = std::cout.rdbuf(this->stdOutBuffer.rdbuf());
+    g_stdErrFile = std::cerr.rdbuf(this->stdErrBuffer.rdbuf());
+
+    this->testCachePath = common::joinPaths(std::string(PROJECT_BINARY_PATH),
+        "test_cache");
+
+    // Clear and recreate the cache at the start of every test. Doing it here
+    // instead of on teardown leaves the folder intact for debugging if needed
+    common::removeAll(testCachePath);
+    common::createDirectories(testCachePath);
+    setenv("IGN_FUEL_CACHE_PATH", this->testCachePath.c_str(), true);
+  }
+
+  // Documentation inherited
+  public: void TearDown() override
+  {
+    // Clear all streams (including state flags).
+    this->stdOutBuffer.str("");
+    this->stdOutBuffer.clear();
+    this->stdErrBuffer.str("");
+    this->stdErrBuffer.clear();
+
+    // Restore stdout and stderr redirections.
+    std::cout.rdbuf(g_stdOutFile);
+    std::cerr.rdbuf(g_stdErrFile);
+  }
+
+  public: std::stringstream stdOutBuffer;
+  public: std::stringstream stdErrBuffer;
+
+  /// \brief Path for a test cache within the build folder
+  public: std::string testCachePath;
+};
 
 /////////////////////////////////////////////////
-// \brief Clear all streams (including state flags).
-void clearIOStreams(std::stringstream &_stdOutBuffer,
-                    std::stringstream &_stdErrBuffer)
+TEST_F(CmdLine, ModelListFail)
 {
-  _stdOutBuffer.str("");
-  _stdOutBuffer.clear();
-  _stdErrBuffer.str("");
-  _stdErrBuffer.clear();
-}
-
-/////////////////////////////////////////////////
-/// \brief Restore stdout and stderr redirections.
-void restoreIO()
-{
-  std::cout.rdbuf(g_stdOutFile);
-  std::cerr.rdbuf(g_stdErrFile);
-}
-
-/////////////////////////////////////////////////
-TEST(CmdLine, ModelListFail)
-{
-  std::stringstream stdOutBuffer;
-  std::stringstream stdErrBuffer;
-  redirectIO(stdOutBuffer, stdErrBuffer);
-
   EXPECT_FALSE(listModels("fake_url"));
 
-  EXPECT_NE(stdOutBuffer.str().find("Invalid URL"),
-      std::string::npos) << stdOutBuffer.str();
-  EXPECT_TRUE(stdErrBuffer.str().empty());
-
-  clearIOStreams(stdOutBuffer, stdErrBuffer);
-  restoreIO();
+  EXPECT_NE(this->stdOutBuffer.str().find("Invalid URL"),
+      std::string::npos) << this->stdOutBuffer.str();
+  EXPECT_TRUE(this->stdErrBuffer.str().empty());
 }
 
 /////////////////////////////////////////////////
 // Protocol "https" not supported or disabled in libcurl for Windows
 // https://github.com/ignitionrobotics/ign-fuel-tools/issues/105
-TEST(CmdLine, ModelListConfigServerUgly)
+TEST_F(CmdLine, ModelListConfigServerUgly)
 {
-  std::stringstream stdOutBuffer;
-  std::stringstream stdErrBuffer;
-  redirectIO(stdOutBuffer, stdErrBuffer);
-
   EXPECT_TRUE(listModels("", "", "true"));
 
-  EXPECT_NE(stdOutBuffer.str().find("https://fuel.ignitionrobotics.org"),
-      std::string::npos) << stdOutBuffer.str();
-  EXPECT_EQ(stdOutBuffer.str().find("owners"), std::string::npos)
-      << stdOutBuffer.str();
-
-  clearIOStreams(stdOutBuffer, stdErrBuffer);
-  restoreIO();
+  EXPECT_NE(this->stdOutBuffer.str().find("https://fuel.ignitionrobotics.org"),
+      std::string::npos) << this->stdOutBuffer.str();
+  EXPECT_EQ(this->stdOutBuffer.str().find("owners"), std::string::npos)
+      << this->stdOutBuffer.str();
 }
 
 /////////////////////////////////////////////////
 // Protocol "https" not supported or disabled in libcurl for Windows
 // https://github.com/ignitionrobotics/ign-fuel-tools/issues/105
-TEST(CmdLine, ModelListConfigServerPretty)
+TEST_F(CmdLine, ModelListConfigServerPretty)
 {
-  std::stringstream stdOutBuffer;
-  std::stringstream stdErrBuffer;
-  redirectIO(stdOutBuffer, stdErrBuffer);
-
   EXPECT_TRUE(listModels("https://staging-fuel.ignitionrobotics.org"));
 
-  EXPECT_NE(stdOutBuffer.str().find(
+  EXPECT_NE(this->stdOutBuffer.str().find(
         "https://staging-fuel.ignitionrobotics.org"),
-      std::string::npos) << stdOutBuffer.str();
-  EXPECT_NE(stdOutBuffer.str().find("owners"), std::string::npos)
-      << stdOutBuffer.str();
-  EXPECT_NE(stdOutBuffer.str().find("models"), std::string::npos)
-      << stdOutBuffer.str();
+      std::string::npos) << this->stdOutBuffer.str();
+  EXPECT_NE(this->stdOutBuffer.str().find("owners"), std::string::npos)
+      << this->stdOutBuffer.str();
+  EXPECT_NE(this->stdOutBuffer.str().find("models"), std::string::npos)
+      << this->stdOutBuffer.str();
 
-  EXPECT_EQ(stdOutBuffer.str().find("https://fuel.ignitionrobotics.org"),
-      std::string::npos) << stdOutBuffer.str();
-  EXPECT_EQ(stdOutBuffer.str().find(
+  EXPECT_EQ(this->stdOutBuffer.str().find("https://fuel.ignitionrobotics.org"),
+      std::string::npos) << this->stdOutBuffer.str();
+  EXPECT_EQ(this->stdOutBuffer.str().find(
       "https://staging-fuel.ignitionrobotics.org/1.0/"), std::string::npos)
-      << stdOutBuffer.str();
-
-  clearIOStreams(stdOutBuffer, stdErrBuffer);
-  restoreIO();
+      << this->stdOutBuffer.str();
 }
 
 /////////////////////////////////////////////////
 // Protocol "https" not supported or disabled in libcurl for Windows
 // https://github.com/ignitionrobotics/ign-fuel-tools/issues/105
-TEST(CmdLine, ModelListConfigServerPrettyOwner)
+TEST_F(CmdLine, ModelListConfigServerPrettyOwner)
 {
-  std::stringstream stdOutBuffer;
-  std::stringstream stdErrBuffer;
-  redirectIO(stdOutBuffer, stdErrBuffer);
-
   EXPECT_TRUE(listModels("https://staging-fuel.ignitionrobotics.org",
       "openrobotics"));
 
-  EXPECT_NE(stdOutBuffer.str().find(
+  EXPECT_NE(this->stdOutBuffer.str().find(
         "https://staging-fuel.ignitionrobotics.org"),
-      std::string::npos) << stdOutBuffer.str();
-  EXPECT_NE(stdOutBuffer.str().find("1 owners"), std::string::npos)
-      << stdOutBuffer.str();
-  EXPECT_NE(stdOutBuffer.str().find("models"), std::string::npos)
-      << stdOutBuffer.str();
+      std::string::npos) << this->stdOutBuffer.str();
+  EXPECT_NE(this->stdOutBuffer.str().find("1 owners"), std::string::npos)
+      << this->stdOutBuffer.str();
+  EXPECT_NE(this->stdOutBuffer.str().find("models"), std::string::npos)
+      << this->stdOutBuffer.str();
 
   // If pagination fails, we only get the first 20 models
-  EXPECT_EQ(stdOutBuffer.str().find("20 models"), std::string::npos)
-      << stdOutBuffer.str();
+  EXPECT_EQ(this->stdOutBuffer.str().find("20 models"), std::string::npos)
+      << this->stdOutBuffer.str();
 
-  EXPECT_EQ(stdOutBuffer.str().find("https://fuel.ignitionrobotics.org"),
-      std::string::npos) << stdOutBuffer.str();
-  EXPECT_EQ(stdOutBuffer.str().find(
+  EXPECT_EQ(this->stdOutBuffer.str().find("https://fuel.ignitionrobotics.org"),
+      std::string::npos) << this->stdOutBuffer.str();
+  EXPECT_EQ(this->stdOutBuffer.str().find(
       "https://staging-fuel.ignitionrobotics.org/1.0/"), std::string::npos)
-      << stdOutBuffer.str();
-
-  clearIOStreams(stdOutBuffer, stdErrBuffer);
-  restoreIO();
+      << this->stdOutBuffer.str();
 }
 
 /////////////////////////////////////////////////
-TEST(CmdLine, ModelDownloadBadUrl)
+TEST_F(CmdLine, ModelDownloadBadUrl)
 {
-  std::stringstream stdOutBuffer;
-  std::stringstream stdErrBuffer;
-  redirectIO(stdOutBuffer, stdErrBuffer);
-
   EXPECT_FALSE(downloadUrl("fake_url"));
 
-  EXPECT_NE(stdOutBuffer.str().find("Malformed URL"),
-      std::string::npos) << stdOutBuffer.str();
-  EXPECT_TRUE(stdErrBuffer.str().empty());
-
-  clearIOStreams(stdOutBuffer, stdErrBuffer);
-  restoreIO();
+  EXPECT_NE(this->stdOutBuffer.str().find("Malformed URL"),
+      std::string::npos) << this->stdOutBuffer.str();
+  EXPECT_TRUE(this->stdErrBuffer.str().empty());
 }
 
 /////////////////////////////////////////////////
-TEST(CmdLine, ModelDownloadWrongUrl)
+TEST_F(CmdLine, ModelDownloadWrongUrl)
 {
-  std::stringstream stdOutBuffer;
-  std::stringstream stdErrBuffer;
-  redirectIO(stdOutBuffer, stdErrBuffer);
-
   EXPECT_FALSE(downloadUrl(
       "https://site.com/1.0/ownername/modelname"));
 
-  EXPECT_NE(stdOutBuffer.str().find("Invalid URL"),
-      std::string::npos) << stdOutBuffer.str();
-  EXPECT_TRUE(stdErrBuffer.str().empty());
-
-  clearIOStreams(stdOutBuffer, stdErrBuffer);
-  restoreIO();
+  EXPECT_NE(this->stdOutBuffer.str().find("Invalid URL"),
+      std::string::npos) << this->stdOutBuffer.str();
+  EXPECT_TRUE(this->stdErrBuffer.str().empty());
 }
 
 /////////////////////////////////////////////////
 // Protocol "https" not supported or disabled in libcurl for Windows
 // https://github.com/ignitionrobotics/ign-fuel-tools/issues/105
-TEST(CmdLine, ModelDownloadUnversioned)
+TEST_F(CmdLine, ModelDownloadUnversioned)
 {
-  cmdVerbosity("4");
-
-  ignition::common::removeAll("test_cache");
-  ignition::common::createDirectories("test_cache");
-  setenv("IGN_FUEL_CACHE_PATH", "test_cache", true);
-
-  std::stringstream stdOutBuffer;
-  std::stringstream stdErrBuffer;
-  redirectIO(stdOutBuffer, stdErrBuffer);
-
   // Download
   EXPECT_TRUE(downloadUrl(
       "https://fuel.ignitionrobotics.org/1.0/chapulina/models/Test box"));
 
   // Check output
-  EXPECT_NE(stdOutBuffer.str().find("Download succeeded"),
-      std::string::npos) << stdOutBuffer.str();
-  EXPECT_TRUE(stdErrBuffer.str().empty()) << stdErrBuffer.str();
+  EXPECT_NE(this->stdOutBuffer.str().find("Download succeeded"),
+      std::string::npos) << this->stdOutBuffer.str();
+  EXPECT_TRUE(this->stdErrBuffer.str().empty()) << this->stdErrBuffer.str();
 
   // Check files
   EXPECT_TRUE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/chapulina/models/test box"));
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+      "chapulina", "models", "test box")));
   EXPECT_TRUE(ignition::common::isDirectory(
-      "test_cache/fuel.ignitionrobotics.org/chapulina/models/test box/2"));
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+      "chapulina", "models", "test box", "2")));
   EXPECT_TRUE(ignition::common::isFile(
-      std::string("test_cache/fuel.ignitionrobotics.org/chapulina/models") +
-      "/test box/2/model.sdf"));
-
-  clearIOStreams(stdOutBuffer, stdErrBuffer);
-  restoreIO();
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+      "chapulina", "models", "test box", "2", "model.sdf")));
 }
 
 /////////////////////////////////////////////////
 // Protocol "https" not supported or disabled in libcurl for Windows
 // https://github.com/ignitionrobotics/ign-fuel-tools/issues/105
-TEST(CmdLine, DownloadConfigCache)
+TEST_F(CmdLine, DownloadConfigCache)
 {
-  cmdVerbosity("4");
-
   unsetenv("IGN_FUEL_CACHE_PATH");
-  ignition::common::removeAll("test_cache");
-  ignition::common::createDirectories("test_cache");
 
   // Test config
   std::ofstream ofs;
-  std::string testPath = common::joinPaths(
-      std::string(PROJECT_BINARY_PATH), "test_cache", "test_conf.yaml");
+  std::string testPath = common::joinPaths(this->testCachePath, "test_conf.yaml");
   ofs.open(testPath, std::ofstream::out | std::ofstream::app);
 
   ofs << "---"                                    << std::endl
@@ -255,13 +213,10 @@ TEST(CmdLine, DownloadConfigCache)
       << "    url: https://fuel.ignitionrobotics.org"  << std::endl
       << ""                                       << std::endl
       << "cache:"                                 << std::endl
-      << "  path: " << PROJECT_BINARY_PATH << "/test_cache" << std::endl
+      << "  path: " << this->testCachePath << std::endl
       << std::endl;
   ofs.close();
-
-  std::stringstream stdOutBuffer;
-  std::stringstream stdErrBuffer;
-  redirectIO(stdOutBuffer, stdErrBuffer);
+  EXPECT_TRUE(common::exists(testPath)) << testPath;
 
   // Download
   EXPECT_TRUE(downloadUrl(
@@ -269,199 +224,140 @@ TEST(CmdLine, DownloadConfigCache)
       testPath.c_str()));
 
   // Check output
-  EXPECT_NE(stdOutBuffer.str().find("Download succeeded"),
-      std::string::npos) << stdOutBuffer.str();
-  EXPECT_TRUE(stdErrBuffer.str().empty()) << stdErrBuffer.str();
+  EXPECT_NE(this->stdOutBuffer.str().find("Download succeeded"),
+      std::string::npos) << this->stdOutBuffer.str();
+  EXPECT_TRUE(this->stdErrBuffer.str().empty()) << this->stdErrBuffer.str();
 
   // Check files
-  auto modelPath = common::joinPaths(std::string(PROJECT_BINARY_PATH),
-      "test_cache", "fuel.ignitionrobotics.org", "chapulina", "models",
-      "test box");
+  auto modelPath = common::joinPaths(this->testCachePath,
+      "fuel.ignitionrobotics.org", "chapulina", "models", "test box");
   EXPECT_TRUE(ignition::common::isDirectory(modelPath));
   EXPECT_TRUE(ignition::common::isDirectory(common::joinPaths(modelPath, "2")));
   EXPECT_TRUE(ignition::common::isFile(common::joinPaths(modelPath, "2",
       "model.sdf")));
-
-  clearIOStreams(stdOutBuffer, stdErrBuffer);
-  restoreIO();
 }
 
 /////////////////////////////////////////////////
-TEST(CmdLine, WorldListFail)
+TEST_F(CmdLine, WorldListFail)
 {
-  std::stringstream stdOutBuffer;
-  std::stringstream stdErrBuffer;
-  redirectIO(stdOutBuffer, stdErrBuffer);
-
   EXPECT_FALSE(listWorlds("fake_url"));
 
-  EXPECT_NE(stdOutBuffer.str().find("Invalid URL"),
-      std::string::npos) << stdOutBuffer.str();
-  EXPECT_TRUE(stdErrBuffer.str().empty());
-
-  clearIOStreams(stdOutBuffer, stdErrBuffer);
-  restoreIO();
+  EXPECT_NE(this->stdOutBuffer.str().find("Invalid URL"),
+      std::string::npos) << this->stdOutBuffer.str();
+  EXPECT_TRUE(this->stdErrBuffer.str().empty());
 }
 
 /////////////////////////////////////////////////
 // Protocol "https" not supported or disabled in libcurl for Windows
 // https://github.com/ignitionrobotics/ign-fuel-tools/issues/105
-TEST(FuelClientTest, WorldListConfigServerUgly)
+TEST_F(CmdLine, WorldListConfigServerUgly)
 {
-  std::stringstream stdOutBuffer;
-  std::stringstream stdErrBuffer;
-  redirectIO(stdOutBuffer, stdErrBuffer);
-
   EXPECT_TRUE(listWorlds(
         "https://staging-fuel.ignitionrobotics.org", "", "true"));
 
-  EXPECT_NE(stdOutBuffer.str().find(
+  EXPECT_NE(this->stdOutBuffer.str().find(
         "https://staging-fuel.ignitionrobotics.org"),
-      std::string::npos) << stdOutBuffer.str();
-  EXPECT_EQ(stdOutBuffer.str().find("owners"), std::string::npos)
-      << stdOutBuffer.str();
-
-  clearIOStreams(stdOutBuffer, stdErrBuffer);
-  restoreIO();
+      std::string::npos) << this->stdOutBuffer.str();
+  EXPECT_EQ(this->stdOutBuffer.str().find("owners"), std::string::npos)
+      << this->stdOutBuffer.str();
 }
 
 /////////////////////////////////////////////////
 // Protocol "https" not supported or disabled in libcurl for Windows
 // https://github.com/ignitionrobotics/ign-fuel-tools/issues/105
-TEST(FuelClientTest, WorldListConfigServerPretty)
+TEST_F(CmdLine, WorldListConfigServerPretty)
 {
-  std::stringstream stdOutBuffer;
-  std::stringstream stdErrBuffer;
-  redirectIO(stdOutBuffer, stdErrBuffer);
-
   EXPECT_TRUE(listWorlds("https://staging-fuel.ignitionrobotics.org"));
 
-  EXPECT_NE(stdOutBuffer.str().find(
+  EXPECT_NE(this->stdOutBuffer.str().find(
         "https://staging-fuel.ignitionrobotics.org"), std::string::npos)
-    << stdOutBuffer.str();
-  EXPECT_NE(stdOutBuffer.str().find("owners"), std::string::npos)
-      << stdOutBuffer.str();
-  EXPECT_NE(stdOutBuffer.str().find("worlds"), std::string::npos)
-      << stdOutBuffer.str();
+    << this->stdOutBuffer.str();
+  EXPECT_NE(this->stdOutBuffer.str().find("owners"), std::string::npos)
+      << this->stdOutBuffer.str();
+  EXPECT_NE(this->stdOutBuffer.str().find("worlds"), std::string::npos)
+      << this->stdOutBuffer.str();
 
-  EXPECT_EQ(stdOutBuffer.str().find("https://fuel.ignitionrobotics.org"),
-      std::string::npos) << stdOutBuffer.str();
-  EXPECT_EQ(stdOutBuffer.str().find(
+  EXPECT_EQ(this->stdOutBuffer.str().find("https://fuel.ignitionrobotics.org"),
+      std::string::npos) << this->stdOutBuffer.str();
+  EXPECT_EQ(this->stdOutBuffer.str().find(
       "https://staging-fuel.ignitionrobotics.org/1.0/"), std::string::npos)
-      << stdOutBuffer.str();
-
-  clearIOStreams(stdOutBuffer, stdErrBuffer);
-  restoreIO();
+      << this->stdOutBuffer.str();
 }
 
 /////////////////////////////////////////////////
-TEST(CmdLine, WorldListCustomServerPrettyOwner)
+TEST_F(CmdLine, WorldListCustomServerPrettyOwner)
 {
-  std::stringstream stdOutBuffer;
-  std::stringstream stdErrBuffer;
-  redirectIO(stdOutBuffer, stdErrBuffer);
-
   EXPECT_TRUE(listWorlds("https://staging-fuel.ignitionrobotics.org",
       "openrobotics"));
 
-  EXPECT_NE(stdOutBuffer.str().find(
+  EXPECT_NE(this->stdOutBuffer.str().find(
         "https://staging-fuel.ignitionrobotics.org"), std::string::npos)
-    << stdOutBuffer.str();
-  EXPECT_NE(stdOutBuffer.str().find("worlds"), std::string::npos)
-      << stdOutBuffer.str();
+    << this->stdOutBuffer.str();
+  EXPECT_NE(this->stdOutBuffer.str().find("worlds"), std::string::npos)
+      << this->stdOutBuffer.str();
 
   // If pagination fails, we only get the first 20 worlds
-  EXPECT_EQ(stdOutBuffer.str().find("20 worlds"), std::string::npos)
-      << stdOutBuffer.str();
+  EXPECT_EQ(this->stdOutBuffer.str().find("20 worlds"), std::string::npos)
+      << this->stdOutBuffer.str();
 
-  EXPECT_EQ(stdOutBuffer.str().find("https://fuel.ignitionrobotics.org"),
-      std::string::npos) << stdOutBuffer.str();
-  EXPECT_EQ(stdOutBuffer.str().find(
+  EXPECT_EQ(this->stdOutBuffer.str().find("https://fuel.ignitionrobotics.org"),
+      std::string::npos) << this->stdOutBuffer.str();
+  EXPECT_EQ(this->stdOutBuffer.str().find(
       "https://staging-fuel.ignitionrobotics.org/1.0/"), std::string::npos)
-      << stdOutBuffer.str();
-
-  clearIOStreams(stdOutBuffer, stdErrBuffer);
-  restoreIO();
+      << this->stdOutBuffer.str();
 }
 
 /////////////////////////////////////////////////
 // Protocol "https" not supported or disabled in libcurl for Windows
 // https://github.com/ignitionrobotics/ign-fuel-tools/issues/105
-TEST(FuelClientTest, WorldDownloadBadUrl)
+TEST_F(CmdLine, WorldDownloadBadUrl)
 {
-  std::stringstream stdOutBuffer;
-  std::stringstream stdErrBuffer;
-  redirectIO(stdOutBuffer, stdErrBuffer);
-
   EXPECT_FALSE(downloadUrl("fake_url"));
 
-  EXPECT_NE(stdOutBuffer.str().find("Malformed URL"),
-      std::string::npos) << stdOutBuffer.str();
-  EXPECT_TRUE(stdErrBuffer.str().empty());
-
-  clearIOStreams(stdOutBuffer, stdErrBuffer);
-  restoreIO();
+  EXPECT_NE(this->stdOutBuffer.str().find("Malformed URL"),
+      std::string::npos) << this->stdOutBuffer.str();
+  EXPECT_TRUE(this->stdErrBuffer.str().empty()) << this->stdErrBuffer.str();
 }
 
 /////////////////////////////////////////////////
-TEST(CmdLine, WorldDownloadWrongUrl)
+TEST_F(CmdLine, WorldDownloadWrongUrl)
 {
-  std::stringstream stdOutBuffer;
-  std::stringstream stdErrBuffer;
-  redirectIO(stdOutBuffer, stdErrBuffer);
-
   EXPECT_FALSE(downloadUrl(
       "https://site.com/1.0/ownername/worldname"));
 
-  EXPECT_NE(stdOutBuffer.str().find("Invalid URL"),
-      std::string::npos) << stdOutBuffer.str();
-  EXPECT_TRUE(stdErrBuffer.str().empty());
-
-  clearIOStreams(stdOutBuffer, stdErrBuffer);
-  restoreIO();
+  EXPECT_NE(this->stdOutBuffer.str().find("Invalid URL"),
+      std::string::npos) << this->stdOutBuffer.str();
+  EXPECT_TRUE(this->stdErrBuffer.str().empty()) << this->stdErrBuffer.str();
 }
 
 /////////////////////////////////////////////////
 // Protocol "https" not supported or disabled in libcurl for Windows
 // https://github.com/ignitionrobotics/ign-fuel-tools/issues/105
-TEST(FuelClientTest, WorldDownloadUnversioned)
+TEST_F(CmdLine, WorldDownloadUnversioned)
 {
-  cmdVerbosity("4");
-
-  ignition::common::removeAll("test_cache");
-  ignition::common::createDirectories("test_cache");
-  setenv("IGN_FUEL_CACHE_PATH", "test_cache", true);
-
-  std::stringstream stdOutBuffer;
-  std::stringstream stdErrBuffer;
-  redirectIO(stdOutBuffer, stdErrBuffer);
-
   // Download
   EXPECT_TRUE(downloadUrl(
       "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Test world"));
 
   // Check output
-  EXPECT_NE(stdOutBuffer.str().find("Download succeeded"),
-      std::string::npos) << stdOutBuffer.str();
-  EXPECT_TRUE(stdErrBuffer.str().empty());
+  EXPECT_NE(this->stdOutBuffer.str().find("Download succeeded"),
+      std::string::npos) << this->stdOutBuffer.str();
+  EXPECT_TRUE(this->stdErrBuffer.str().empty()) << this->stdErrBuffer.str();
 
   // Check files
   EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world")));
   EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world", "2")));
   EXPECT_TRUE(ignition::common::isFile(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world", "2", "test.world")));
-
-  clearIOStreams(stdOutBuffer, stdErrBuffer);
-  restoreIO();
 }
 
 class DownloadCollectionTest
-    : public ::testing::Test,
+    : public CmdLine,
       public ::testing::WithParamInterface<int>
 {};
 
@@ -473,16 +369,6 @@ INSTANTIATE_TEST_CASE_P(CollectionTest, DownloadCollectionTest,
 // https://github.com/ignitionrobotics/ign-fuel-tools/issues/105
 TEST_P(DownloadCollectionTest, AllItems)
 {
-  cmdVerbosity("4");
-
-  ignition::common::removeAll("test_cache");
-  ignition::common::createDirectories("test_cache");
-  setenv("IGN_FUEL_CACHE_PATH", "test_cache", true);
-
-  std::stringstream stdOutBuffer;
-  std::stringstream stdErrBuffer;
-  redirectIO(stdOutBuffer, stdErrBuffer);
-
   // Download
   EXPECT_TRUE(
       downloadUrl("https://fuel.ignitionrobotics.org/1.0/OpenRobotics/"
@@ -490,57 +376,54 @@ TEST_P(DownloadCollectionTest, AllItems)
                   nullptr, nullptr, nullptr, GetParam()));
 
   // Check output
-  EXPECT_NE(stdOutBuffer.str().find("Download succeeded"), std::string::npos)
-      << stdOutBuffer.str();
-  EXPECT_TRUE(stdErrBuffer.str().empty())
-      << stdErrBuffer.str();
+  EXPECT_NE(this->stdOutBuffer.str().find("Download succeeded"), std::string::npos)
+      << this->stdOutBuffer.str();
+  EXPECT_TRUE(this->stdErrBuffer.str().empty()) << this->stdErrBuffer.str();
 
   // Check files
   // Model: Backpack
   EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "models", "backpack")));
   EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "models", "backpack", "2")));
   EXPECT_TRUE(ignition::common::isFile(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "models", "backpack", "2", "model.sdf")));
 
   // Model: TEAMBASE
   EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "models", "teambase")));
   EXPECT_TRUE(ignition::common::isDirectory(
-     ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "models", "teambase", "2")));
   EXPECT_TRUE(ignition::common::isFile(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
      "openrobotics", "models", "teambase", "2", "model.sdf")));
 
   // World: Test World
   EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world")));
   EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world", "2")));
   EXPECT_TRUE(ignition::common::isFile(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world", "2", "test.world")));
 
   // World: Test World 2
   EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world 2")));
   EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world 2", "2")));
   EXPECT_TRUE(ignition::common::isFile(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world 2", "2", "test.world")));
-  clearIOStreams(stdOutBuffer, stdErrBuffer);
-  restoreIO();
 }
 
 /////////////////////////////////////////////////
@@ -549,16 +432,6 @@ TEST_P(DownloadCollectionTest, AllItems)
 // https://github.com/ignitionrobotics/ign-fuel-tools/issues/105
 TEST_P(DownloadCollectionTest, Models)
 {
-  cmdVerbosity("4");
-
-  ignition::common::removeAll("test_cache");
-  ignition::common::createDirectories("test_cache");
-  setenv("IGN_FUEL_CACHE_PATH", "test_cache", true);
-
-  std::stringstream stdOutBuffer;
-  std::stringstream stdErrBuffer;
-  redirectIO(stdOutBuffer, stdErrBuffer);
-
   // Download
   EXPECT_TRUE(
       downloadUrl("https://fuel.ignitionrobotics.org/1.0/OpenRobotics/"
@@ -566,44 +439,42 @@ TEST_P(DownloadCollectionTest, Models)
                   nullptr, nullptr, "model", GetParam()));
 
   // Check output
-  EXPECT_NE(stdOutBuffer.str().find("Download succeeded"), std::string::npos)
-      << stdOutBuffer.str();
-  EXPECT_TRUE(stdErrBuffer.str().empty());
+  EXPECT_NE(this->stdOutBuffer.str().find("Download succeeded"), std::string::npos)
+      << this->stdOutBuffer.str();
+  EXPECT_TRUE(this->stdErrBuffer.str().empty()) << this->stdErrBuffer.str();
 
   // Check files
   // Model: Backpack
   EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "models", "backpack")));
   EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "models", "backpack", "2")));
   EXPECT_TRUE(ignition::common::isFile(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "models", "backpack", "2", "model.sdf")));
 
   // Model: TEAMBASE
   EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "models", "teambase")));
   EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "models", "teambase", "2")));
   EXPECT_TRUE(ignition::common::isFile(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "models", "teambase", "2", "model.sdf")));
 
   // World: Test World
   EXPECT_FALSE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world")));
 
   // World: Test World 2
   EXPECT_FALSE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world2")));
-  clearIOStreams(stdOutBuffer, stdErrBuffer);
-  restoreIO();
 }
 
 /////////////////////////////////////////////////
@@ -612,16 +483,6 @@ TEST_P(DownloadCollectionTest, Models)
 // https://github.com/ignitionrobotics/ign-fuel-tools/issues/105
 TEST_P(DownloadCollectionTest, Worlds)
 {
-  cmdVerbosity("4");
-
-  ignition::common::removeAll("test_cache");
-  ignition::common::createDirectories("test_cache");
-  setenv("IGN_FUEL_CACHE_PATH", "test_cache", true);
-
-  std::stringstream stdOutBuffer;
-  std::stringstream stdErrBuffer;
-  redirectIO(stdOutBuffer, stdErrBuffer);
-
   // Download
   EXPECT_TRUE(
       downloadUrl("https://fuel.ignitionrobotics.org/1.0/OpenRobotics/"
@@ -629,43 +490,40 @@ TEST_P(DownloadCollectionTest, Worlds)
                   nullptr, nullptr, "world", GetParam()));
 
   // Check output
-  EXPECT_NE(stdOutBuffer.str().find("Download succeeded"), std::string::npos)
-      << stdOutBuffer.str();
-  EXPECT_TRUE(stdErrBuffer.str().empty())
-      << stdErrBuffer.str();
+  EXPECT_NE(this->stdOutBuffer.str().find("Download succeeded"), std::string::npos)
+      << this->stdOutBuffer.str();
+  EXPECT_TRUE(this->stdErrBuffer.str().empty()) << this->stdErrBuffer.str();
 
   // Check files
   // Model: Backpack
   EXPECT_FALSE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "models", "backpack")));
 
   // Model: TEAMBASE
   EXPECT_FALSE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "models", "teambase")));
 
   // World: Test World
   EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world")));
   EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world", "2")));
   EXPECT_TRUE(ignition::common::isFile(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world", "2", "test.world")));
 
   // World: Test World 2
   EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world 2")));
   EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world 2", "2")));
   EXPECT_TRUE(ignition::common::isFile(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world 2", "2", "test.world")));
-  clearIOStreams(stdOutBuffer, stdErrBuffer);
-  restoreIO();
 }


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

While debugging a test failure, I noticed that the tests in `ign_src_TEST` would fail if run from outside the build directory. So I fixed this by passing `PROJECT_BINARY_PATH` to all the places where the `test_cache` is accessed. In order to reduce duplication, I moved that logic to the `SetUp` function. While at it, I reduced more duplication by moving the `IO` functions to `SetUp` / `TearDown`.

The fix can be checked by running the test from a directory other than `build`, for example:

`./build/ignition-fuel_tools5/bin/UNIT_ign_src_TEST`

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
