### PR TITLE
Improve and fix ResultType tests

### DIFF
--- a/src/FuelClient_TEST.cc
+++ b/src/FuelClient_TEST.cc
@@ -417,13 +417,13 @@ TEST_F(FuelClientTest, DownloadModel)
     std::string cachedPath;
     Result res1 = client.CachedModel(url, cachedPath);
     EXPECT_FALSE(res1);
-    EXPECT_EQ(Result(ResultType::FETCH_ERROR), res1);
+    EXPECT_EQ(ResultType::FETCH_ERROR, res1.Type());
 
     // Download
     std::string path;
     Result res2 = client.DownloadModel(url, path);
     EXPECT_TRUE(res2);
-    EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res2);
+    EXPECT_EQ(ResultType::FETCH, res2.Type());
 
     // Check it was downloaded to `2`
     auto modelPath = common::joinPaths(common::cwd(), "test_cache",
@@ -441,7 +441,7 @@ TEST_F(FuelClientTest, DownloadModel)
     // Check it is cached
     Result res3 = client.CachedModel(url, cachedPath);
     EXPECT_TRUE(res3);
-    EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res3);
+    EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, res3.Type());
     EXPECT_EQ(common::joinPaths(modelPath, "2"), cachedPath);
   }
 
@@ -455,13 +455,13 @@ TEST_F(FuelClientTest, DownloadModel)
     std::string cachedPath;
     Result res1 = client.CachedModel(url, cachedPath);
     EXPECT_FALSE(res1);
-    EXPECT_EQ(Result(ResultType::FETCH_ERROR), res1);
+    EXPECT_EQ(ResultType::FETCH_ERROR, res1.Type());
 
     // Download
     std::string path;
     Result res2 = client.DownloadModel(url, path);
     EXPECT_TRUE(res2);
-    EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res2);
+    EXPECT_EQ(ResultType::FETCH, res2.Type());
 
     // Check it was downloaded to `2`
     auto modelPath = common::joinPaths(common::cwd(), "test_cache",
@@ -479,7 +479,7 @@ TEST_F(FuelClientTest, DownloadModel)
     // Check it is cached
     Result res3 = client.CachedModel(url, cachedPath);
     EXPECT_TRUE(res3);
-    EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res3);
+    EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, res3.Type());
     EXPECT_EQ(common::joinPaths(modelPath, "2"), cachedPath);
 
     // Check that URIs have been updated.
@@ -510,28 +510,28 @@ TEST_F(FuelClientTest, DownloadModel)
     std::string cachedPath;
     Result res1 = client.CachedModel(url, cachedPath);
     EXPECT_FALSE(res1);
-    EXPECT_EQ(Result(ResultType::FETCH_ERROR), res1);
+    EXPECT_EQ(ResultType::FETCH_ERROR, res1.Type());
 
     // Check the dependency is not cached
     Result res2 = client.CachedModel(depUrl, cachedPath);
     EXPECT_FALSE(res2);
-    EXPECT_EQ(Result(ResultType::FETCH_ERROR), res2);
+    EXPECT_EQ(ResultType::FETCH_ERROR, res2.Type());
 
     // Download
     std::string path;
     Result res3 = client.DownloadModel(url, path);
     EXPECT_TRUE(res3);
-    EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res3);
+    EXPECT_EQ(ResultType::FETCH, res3.Type());
 
     // Check it is cached
     Result res4 = client.CachedModel(url, cachedPath);
     EXPECT_TRUE(res4);
-    EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res4);
+    EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, res4.Type());
 
     // Check the dependency is cached
     Result res5 = client.CachedModel(depUrl, cachedPath);
     EXPECT_TRUE(res5);
-    EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res5);
+    EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, res5.Type());
   }
 
   // Download model with a dependency specified within its `model.config`
@@ -545,28 +545,28 @@ TEST_F(FuelClientTest, DownloadModel)
     std::string cachedPath;
     Result res1 = client.CachedModel(url, cachedPath);
     EXPECT_FALSE(res1);
-    EXPECT_EQ(Result(ResultType::FETCH_ERROR), res1);
+    EXPECT_EQ(ResultType::FETCH_ERROR, res1.Type());
 
     // Check the dependency is not cached
     Result res2 = client.CachedModel(depUrl, cachedPath);
     EXPECT_FALSE(res2);
-    EXPECT_EQ(Result(ResultType::FETCH_ERROR), res2);
+    EXPECT_EQ(ResultType::FETCH_ERROR, res2.Type());
 
     // Download
     std::string path;
     Result res3 = client.DownloadModel(url, path);
     EXPECT_TRUE(res3);
-    EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res3);
+    EXPECT_EQ(ResultType::FETCH, res3.Type());
 
     // Check it is cached
     Result res4 = client.CachedModel(url, cachedPath);
     EXPECT_TRUE(res4);
-    EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res4);
+    EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, res4.Type());
 
     // Check the dependency is cached
     Result res5 = client.CachedModel(depUrl, cachedPath);
     EXPECT_TRUE(res5);
-    EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res5);
+    EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, res5.Type());
   }
 
   // Try using nonexistent URL
@@ -577,7 +577,7 @@ TEST_F(FuelClientTest, DownloadModel)
     std::string path;
     Result result = client.DownloadModel(common::URI(url), path);
     EXPECT_FALSE(result);
-    EXPECT_EQ(Result(ResultType::FETCH_ERROR), result);
+    EXPECT_EQ(ResultType::FETCH_ERROR, result.Type());
   }
 
   // Try using bad URL
@@ -586,7 +586,7 @@ TEST_F(FuelClientTest, DownloadModel)
     std::string path;
     Result result = client.DownloadModel(common::URI(url), path);
     EXPECT_FALSE(result);
-    EXPECT_EQ(Result(ResultType::FETCH_ERROR), result);
+    EXPECT_EQ(ResultType::FETCH_ERROR, result.Type());
   }
 }
 
@@ -623,19 +623,19 @@ TEST_F(FuelClientTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(ModelDependencies))
     std::string cachedPath;
     Result res1 = client.CachedModel(url, cachedPath);
     EXPECT_FALSE(res1);
-    EXPECT_EQ(Result(ResultType::FETCH_ERROR), res1);
+    EXPECT_EQ(ResultType::FETCH_ERROR, res1.Type());
 
     // Check the dependency is not cached
     Result res2 = client.CachedModel(depUrl, cachedPath);
     EXPECT_FALSE(res2);
-    EXPECT_EQ(Result(ResultType::FETCH_ERROR), res2);
+    EXPECT_EQ(ResultType::FETCH_ERROR, res2.Type());
 
     // Download on the model, do not download dependencies
     {
       std::vector<ModelIdentifier> dependencies;
       Result res3 = client.DownloadModel(id, {}, dependencies);
       EXPECT_TRUE(res3);
-      EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res3);
+      EXPECT_EQ(ResultType::FETCH, res3.Type());
       EXPECT_EQ(1u, dependencies.size());
     }
 
@@ -643,14 +643,14 @@ TEST_F(FuelClientTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(ModelDependencies))
     {
       Result res4 = client.CachedModel(url, cachedPath);
       EXPECT_TRUE(res4);
-      EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res4);
+      EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, res4.Type());
     }
 
     // Check the dependency is not cached
     {
       Result res5 = client.CachedModel(depUrl, cachedPath);
       EXPECT_FALSE(res5);
-      EXPECT_EQ(Result(ResultType::FETCH_ERROR), res5);
+      EXPECT_EQ(ResultType::FETCH_ERROR, res5.Type());
     }
 
     // Check that the dependencies are populated
@@ -687,7 +687,7 @@ TEST_F(FuelClientTest, CachedModel)
     std::string path;
     auto result = client.CachedModel(url, path);
     EXPECT_TRUE(result);
-    EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), result);
+    EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, result.Type());
     EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache", "localhost:8007",
         "alice", "models", "My Model", "3"), path);
   }
@@ -698,7 +698,7 @@ TEST_F(FuelClientTest, CachedModel)
     std::string path;
     auto result = client.CachedModel(url, path);
     EXPECT_TRUE(result);
-    EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), result);
+    EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, result.Type());
     EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache", "localhost:8007",
         "alice", "models", "My Model", "3"), path);
   }
@@ -709,7 +709,7 @@ TEST_F(FuelClientTest, CachedModel)
     std::string path;
     auto result = client.CachedModel(url, path);
     EXPECT_TRUE(result);
-    EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), result);
+    EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, result.Type());
     EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache", "localhost:8007",
         "alice", "models", "My Model", "2"), path);
   }
@@ -721,7 +721,7 @@ TEST_F(FuelClientTest, CachedModel)
     std::string path;
     auto result = client.CachedModelFile(url, path);
     EXPECT_TRUE(result);
-    EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), result);
+    EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, result.Type());
     EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache", "localhost:8007",
         "alice", "models", "My Model", "3", "model.sdf"), path);
   }
@@ -733,7 +733,7 @@ TEST_F(FuelClientTest, CachedModel)
     std::string path;
     auto result = client.CachedModelFile(url, path);
     EXPECT_TRUE(result);
-    EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), result);
+    EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, result.Type());
     EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache", "localhost:8007",
         "alice", "models", "My Model", "2", "meshes", "model.dae"), path);
   }
@@ -744,7 +744,7 @@ TEST_F(FuelClientTest, CachedModel)
     std::string path;
     auto result = client.CachedModel(url, path);
     EXPECT_FALSE(result);
-    EXPECT_EQ(Result(ResultType::FETCH_ERROR), result);
+    EXPECT_EQ(ResultType::FETCH_ERROR, result.Type());
   }
 
   // Non-cached model (when looking for file)
@@ -753,7 +753,7 @@ TEST_F(FuelClientTest, CachedModel)
     std::string path;
     auto result = client.CachedModelFile(url, path);
     EXPECT_FALSE(result);
-    EXPECT_EQ(Result(ResultType::FETCH_ERROR), result);
+    EXPECT_EQ(ResultType::FETCH_ERROR, result.Type());
   }
 
   // Non-cached model file
@@ -764,7 +764,7 @@ TEST_F(FuelClientTest, CachedModel)
     std::string path;
     auto result = client.CachedModelFile(url, path);
     EXPECT_FALSE(result);
-    EXPECT_EQ(Result(ResultType::FETCH_ERROR), result);
+    EXPECT_EQ(ResultType::FETCH_ERROR, result.Type());
   }
 
   // Model root URL to model file
@@ -773,7 +773,7 @@ TEST_F(FuelClientTest, CachedModel)
     std::string path;
     auto result = client.CachedModelFile(url, path);
     EXPECT_FALSE(result);
-    EXPECT_EQ(Result(ResultType::FETCH_ERROR), result);
+    EXPECT_EQ(ResultType::FETCH_ERROR, result.Type());
   }
 
   // Bad model URL
@@ -782,7 +782,7 @@ TEST_F(FuelClientTest, CachedModel)
     std::string path;
     auto result = client.CachedModel(url, path);
     EXPECT_FALSE(result);
-    EXPECT_EQ(Result(ResultType::FETCH_ERROR), result);
+    EXPECT_EQ(ResultType::FETCH_ERROR, result.Type());
   }
 
   // Bad model file URL
@@ -791,7 +791,7 @@ TEST_F(FuelClientTest, CachedModel)
     std::string path;
     auto result = client.CachedModelFile(url, path);
     EXPECT_FALSE(result);
-    EXPECT_EQ(Result(ResultType::FETCH_ERROR), result);
+    EXPECT_EQ(ResultType::FETCH_ERROR, result.Type());
   }
 }
 
@@ -1086,13 +1086,13 @@ TEST_F(FuelClientTest, DownloadWorld)
     std::string cachedPath;
     auto res1 = client.CachedWorld(url, cachedPath);
     EXPECT_FALSE(res1);
-    EXPECT_EQ(Result(ResultType::FETCH_ERROR), res1);
+    EXPECT_EQ(ResultType::FETCH_ERROR, res1.Type());
 
     // Download
     std::string path;
     auto res2 = client.DownloadWorld(url, path);
     EXPECT_TRUE(res2);
-    EXPECT_EQ(Result(ResultType::FETCH), res2);
+    EXPECT_EQ(ResultType::FETCH, res2.Type());
 
     // Check it was downloaded to `1`
     auto worldPath = common::joinPaths(common::cwd(), "test_cache",
@@ -1108,7 +1108,7 @@ TEST_F(FuelClientTest, DownloadWorld)
     // Check it is cached
     auto res3 = client.CachedWorld(url, cachedPath);
     EXPECT_TRUE(res3);
-    EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res3);
+    EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, res3.Type());
     EXPECT_EQ(common::joinPaths(worldPath, "2"), cachedPath);
   }
 
@@ -1119,7 +1119,7 @@ TEST_F(FuelClientTest, DownloadWorld)
     std::string path;
     auto result = client.DownloadWorld(url, path);
     EXPECT_FALSE(result);
-    EXPECT_EQ(Result(ResultType::FETCH_ERROR), result);
+    EXPECT_EQ(ResultType::FETCH_ERROR, result.Type());
   }
 
   // Try using bad URL
@@ -1128,7 +1128,7 @@ TEST_F(FuelClientTest, DownloadWorld)
     std::string path;
     auto result = client.DownloadWorld(url, path);
     EXPECT_FALSE(result);
-    EXPECT_EQ(Result(ResultType::FETCH_ERROR), result);
+    EXPECT_EQ(ResultType::FETCH_ERROR, result.Type());
   }
 }
 
@@ -1155,7 +1155,7 @@ TEST_F(FuelClientTest, CachedWorld)
     std::string path;
     auto result = client.CachedWorld(url, path);
     EXPECT_TRUE(result);
-    EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), result);
+    EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, result.Type());
     EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
         "localhost:8007", "banana", "worlds", "My World", "3"), path);
   }
@@ -1166,7 +1166,7 @@ TEST_F(FuelClientTest, CachedWorld)
     std::string path;
     auto result = client.CachedWorld(url, path);
     EXPECT_TRUE(result);
-    EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), result);
+    EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, result.Type());
     EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
         "localhost:8007", "banana", "worlds", "My World", "3"), path);
   }
@@ -1177,7 +1177,7 @@ TEST_F(FuelClientTest, CachedWorld)
     std::string path;
     auto result = client.CachedWorld(url, path);
     EXPECT_TRUE(result);
-    EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), result);
+    EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, result.Type());
     EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
         "localhost:8007", "banana", "worlds", "My World", "2"), path);
   }
@@ -1189,7 +1189,7 @@ TEST_F(FuelClientTest, CachedWorld)
     std::string path;
     auto result = client.CachedWorldFile(url, path);
     EXPECT_TRUE(result);
-    EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), result);
+    EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, result.Type());
     EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
         "localhost:8007", "banana", "worlds", "My World", "3",
         "strawberry.world"), path);
@@ -1202,7 +1202,7 @@ TEST_F(FuelClientTest, CachedWorld)
     std::string path;
     auto result = client.CachedWorldFile(url, path);
     EXPECT_TRUE(result);
-    EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), result);
+    EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, result.Type());
     EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
         "localhost:8007", "banana", "worlds", "My World", "2",
         "strawberry.world"), path);
@@ -1214,7 +1214,7 @@ TEST_F(FuelClientTest, CachedWorld)
     std::string path;
     auto result = client.CachedWorld(url, path);
     EXPECT_FALSE(result);
-    EXPECT_EQ(Result(ResultType::FETCH_ERROR), result);
+    EXPECT_EQ(ResultType::FETCH_ERROR, result.Type());
   }
 
   // Non-cached world (when looking for file)
@@ -1224,7 +1224,7 @@ TEST_F(FuelClientTest, CachedWorld)
     std::string path;
     auto result = client.CachedWorldFile(url, path);
     EXPECT_FALSE(result);
-    EXPECT_EQ(Result(ResultType::FETCH_ERROR), result);
+    EXPECT_EQ(ResultType::FETCH_ERROR, result.Type());
   }
 
   // Non-cached world file
@@ -1234,7 +1234,7 @@ TEST_F(FuelClientTest, CachedWorld)
     std::string path;
     auto result = client.CachedWorldFile(url, path);
     EXPECT_FALSE(result);
-    EXPECT_EQ(Result(ResultType::FETCH_ERROR), result);
+    EXPECT_EQ(ResultType::FETCH_ERROR, result.Type());
   }
 
   // World root URL to world file
@@ -1243,7 +1243,7 @@ TEST_F(FuelClientTest, CachedWorld)
     std::string path;
     auto result = client.CachedWorldFile(url, path);
     EXPECT_FALSE(result);
-    EXPECT_EQ(Result(ResultType::FETCH_ERROR), result);
+    EXPECT_EQ(ResultType::FETCH_ERROR, result.Type());
   }
 
   // Bad world URL
@@ -1252,7 +1252,7 @@ TEST_F(FuelClientTest, CachedWorld)
     std::string path;
     auto result = client.CachedWorld(url, path);
     EXPECT_FALSE(result);
-    EXPECT_EQ(Result(ResultType::FETCH_ERROR), result);
+    EXPECT_EQ(ResultType::FETCH_ERROR, result.Type());
   }
 
   // Bad world file URL
@@ -1261,7 +1261,7 @@ TEST_F(FuelClientTest, CachedWorld)
     std::string path;
     auto result = client.CachedWorldFile(url, path);
     EXPECT_FALSE(result);
-    EXPECT_EQ(Result(ResultType::FETCH_ERROR), result);
+    EXPECT_EQ(ResultType::FETCH_ERROR, result.Type());
   }
 }
 

--- a/src/Interface_TEST.cc
+++ b/src/Interface_TEST.cc
@@ -64,7 +64,7 @@ TEST(Interface, FetchResources)
     {
       Result res = client.CachedModel(modelUrl, cachedPath);
       EXPECT_FALSE(res) << "Cached Path: " << cachedPath;
-      EXPECT_EQ(Result(ResultType::FETCH_ERROR), res);
+      EXPECT_EQ(ResultType::FETCH_ERROR, res.Type());
     }
 
     // Download model
@@ -92,7 +92,7 @@ TEST(Interface, FetchResources)
     {
       Result res = client.CachedModel(modelUrl, cachedPath);
       EXPECT_TRUE(res);
-      EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res);
+      EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, res.Type());
       EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
         "fuel.ignitionrobotics.org", "chapulina", "models", "test box", "2"),
         cachedPath);
@@ -111,12 +111,12 @@ TEST(Interface, FetchResources)
     {
       Result res = client.CachedModel(modelUrl, cachedPath);
       EXPECT_FALSE(res) << "Cached Path: " << cachedPath;
-      EXPECT_EQ(Result(ResultType::FETCH_ERROR), res);
+      EXPECT_EQ(ResultType::FETCH_ERROR, res.Type());
     }
     {
       Result res = client.CachedModelFile(modelFileUrl, cachedPath);
       EXPECT_FALSE(res) << "Cached Path: " << cachedPath;
-      EXPECT_EQ(Result(ResultType::FETCH_ERROR), res);
+      EXPECT_EQ(ResultType::FETCH_ERROR, res.Type());
     }
 
     // Download model file
@@ -150,7 +150,7 @@ TEST(Interface, FetchResources)
     {
       Result res = client.CachedModel(modelUrl, cachedPath);
       EXPECT_TRUE(res);
-      EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res);
+      EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, res.Type());
       EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
         "fuel.ignitionrobotics.org", "openrobotics", "models", "bus", "1"),
         cachedPath);
@@ -160,7 +160,7 @@ TEST(Interface, FetchResources)
     {
       Result res = client.CachedModelFile(modelFileUrl, cachedPath);
       EXPECT_TRUE(res);
-      EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res);
+      EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, res.Type());
       EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
         "fuel.ignitionrobotics.org", "openrobotics", "models", "bus", "1",
         "meshes", "bus.obj"), cachedPath);
@@ -175,7 +175,7 @@ TEST(Interface, FetchResources)
     {
       Result res = client.CachedWorld(worldUrl, cachedPath);
       EXPECT_FALSE(res) << "Cached Path: " << cachedPath;
-      EXPECT_EQ(Result(ResultType::FETCH_ERROR), res);
+      EXPECT_EQ(ResultType::FETCH_ERROR, res.Type());
     }
 
     // Download world
@@ -196,7 +196,7 @@ TEST(Interface, FetchResources)
     {
       Result res = client.CachedWorld(worldUrl, cachedPath);
       EXPECT_TRUE(res);
-      EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res);
+      EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, res.Type());
       EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
         "fuel.ignitionrobotics.org", "openrobotics", "worlds", "test world",
         "2"), cachedPath);
@@ -215,12 +215,12 @@ TEST(Interface, FetchResources)
     {
       Result res = client.CachedWorld(worldUrl, cachedPath);
       EXPECT_FALSE(res) << "Cached Path: " << cachedPath;
-      EXPECT_EQ(Result(ResultType::FETCH_ERROR), res);
+      EXPECT_EQ(ResultType::FETCH_ERROR, res.Type());
     }
     {
       Result res = client.CachedWorldFile(worldFileUrl, cachedPath);
       EXPECT_FALSE(res) << "Cached Path: " << cachedPath;
-      EXPECT_EQ(Result(ResultType::FETCH_ERROR), res);
+      EXPECT_EQ(ResultType::FETCH_ERROR, res.Type());
     }
 
     // Download world file
@@ -241,7 +241,7 @@ TEST(Interface, FetchResources)
     {
       Result res = client.CachedWorld(worldUrl, cachedPath);
       EXPECT_TRUE(res);
-      EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res);
+      EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, res.Type());
       EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
         "fuel.ignitionrobotics.org", "chapulina", "worlds", "test world", "2"),
         cachedPath);
@@ -251,7 +251,7 @@ TEST(Interface, FetchResources)
     {
       Result res = client.CachedWorldFile(worldFileUrl, cachedPath);
       EXPECT_TRUE(res);
-      EXPECT_EQ(Result(ResultType::FETCH_ALREADY_EXISTS), res);
+      EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, res.Type());
       EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
         "fuel.ignitionrobotics.org", "chapulina", "worlds", "test world", "2",
         "thumbnails", "1.png"), cachedPath);


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

While debugging test failures on #224, I noticed that some of our `ResultType` tests were comparing `Result` objects converted to booleans instead of the result types themselves. This PR makes sure we're comparing the types and fixes some test expectations.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
