### PR TITLE
More checks when manipulating file system in tests

### DIFF
--- a/src/ClientConfig_TEST.cc
+++ b/src/ClientConfig_TEST.cc
@@ -413,6 +413,8 @@ TEST(ServerConfig, Url)
     ServerConfig srv;
     srv.SetUrl(common::URI("http://banana:8080/"));
     EXPECT_EQ("http://banana:8080", srv.Url().Str());
+    EXPECT_EQ("http", srv.Url().Scheme());
+    EXPECT_EQ("banana:8080", srv.Url().Path().Str());
   }
 
   // Set from URI

--- a/src/FuelClient_TEST.cc
+++ b/src/FuelClient_TEST.cc
@@ -879,13 +879,14 @@ TEST_F(FuelClientTest, ParseWorldUrl)
   // * with client config
   // * without server API version
   // * with world version `tip`
+  // * with trailing /
   {
     ClientConfig config;
 
     FuelClient client(config);
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/german/worlds/Cardboard Box/tip"};
+      "https://fuel.ignitionrobotics.org/german/worlds/Cardboard Box/tip/"};
     EXPECT_TRUE(client.ParseWorldUrl(url, id));
 
     EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");

--- a/src/FuelClient_TEST.cc
+++ b/src/FuelClient_TEST.cc
@@ -50,8 +50,10 @@ void createLocalModel(ClientConfig &_conf)
   auto modelPath = common::joinPaths(
       "test_cache", "localhost:8007", "alice", "models", "My Model");
 
-  common::createDirectories(common::joinPaths(modelPath, "2", "meshes"));
-  common::createDirectories(common::joinPaths(modelPath, "3", "meshes"));
+  EXPECT_TRUE(common::createDirectories(
+      common::joinPaths(modelPath, "2", "meshes")));
+  EXPECT_TRUE(common::createDirectories(
+      common::joinPaths(modelPath, "3", "meshes")));
 
   {
     std::ofstream fout(common::joinPaths(modelPath, "2", "model.config"),
@@ -60,8 +62,8 @@ void createLocalModel(ClientConfig &_conf)
     fout.flush();
     fout.close();
 
-    common::copyFile(common::joinPaths(modelPath, "2", "model.config"),
-        common::joinPaths(modelPath, "3", "model.config"));
+    EXPECT_TRUE(common::copyFile(common::joinPaths(modelPath, "2",
+        "model.config"), common::joinPaths(modelPath, "3", "model.config")));
   }
 
   {
@@ -71,8 +73,8 @@ void createLocalModel(ClientConfig &_conf)
     fout.flush();
     fout.close();
 
-    common::copyFile(common::joinPaths(modelPath, "2", "model.sdf"),
-        common::joinPaths(modelPath, "3", "model.sdf"));
+    EXPECT_TRUE(common::copyFile(common::joinPaths(modelPath, "2", "model.sdf"),
+        common::joinPaths(modelPath, "3", "model.sdf")));
   }
 
   {
@@ -82,8 +84,9 @@ void createLocalModel(ClientConfig &_conf)
     fout.flush();
     fout.close();
 
-    common::copyFile(common::joinPaths(modelPath, "2", "meshes", "model.dae"),
-        common::joinPaths(modelPath, "3", "meshes", "model.dae"));
+    EXPECT_TRUE(common::copyFile(common::joinPaths(modelPath, "2", "meshes",
+        "model.dae"), common::joinPaths(modelPath, "3", "meshes",
+        "model.dae")));
   }
 
   ignition::fuel_tools::ServerConfig srv;
@@ -102,8 +105,8 @@ void createLocalWorld(ClientConfig &_conf)
   auto worldPath = common::joinPaths(
       "test_cache", "localhost:8007", "banana", "worlds", "My World");
 
-  common::createDirectories(common::joinPaths(worldPath, "2"));
-  common::createDirectories(common::joinPaths(worldPath, "3"));
+  EXPECT_TRUE(common::createDirectories(common::joinPaths(worldPath, "2")));
+  EXPECT_TRUE(common::createDirectories(common::joinPaths(worldPath, "3")));
 
   {
     std::ofstream fout(common::joinPaths(worldPath, "2", "strawberry.world"),
@@ -112,8 +115,9 @@ void createLocalWorld(ClientConfig &_conf)
     fout.flush();
     fout.close();
 
-    common::copyFile(common::joinPaths(worldPath, "2", "strawberry.world"),
-        common::joinPaths(worldPath, "3", "strawberry.world"));
+    EXPECT_TRUE(common::copyFile(common::joinPaths(worldPath, "2",
+        "strawberry.world"), common::joinPaths(worldPath, "3",
+        "strawberry.world")));
   }
 
   ignition::fuel_tools::ServerConfig srv;
@@ -398,8 +402,8 @@ TEST_F(FuelClientTest, DownloadModel)
 {
   // Configure to use binary path as cache
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
-  common::removeAll("test_cache");
-  common::createDirectories("test_cache");
+  EXPECT_TRUE(common::removeAll("test_cache"));
+  EXPECT_TRUE(common::createDirectories("test_cache"));
   ClientConfig config;
   config.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
 
@@ -597,8 +601,8 @@ TEST_F(FuelClientTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(ModelDependencies))
 {
   // Configure to use binary path as cache
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
-  common::removeAll("test_cache");
-  common::createDirectories("test_cache");
+  EXPECT_TRUE(common::removeAll("test_cache"));
+  EXPECT_TRUE(common::createDirectories("test_cache"));
   ClientConfig config;
   config.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
 
@@ -671,8 +675,8 @@ TEST_F(FuelClientTest, CachedModel)
 {
   // Configure to use binary path as cache and populate it
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
-  common::removeAll("test_cache");
-  common::createDirectories("test_cache");
+  EXPECT_TRUE(common::removeAll("test_cache"));
+  EXPECT_TRUE(common::createDirectories("test_cache"));
   ClientConfig config;
   config.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
   createLocalModel(config);
@@ -1061,8 +1065,8 @@ TEST_F(FuelClientTest, DownloadWorld)
 {
   // Configure to use binary path as cache
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
-  common::removeAll("test_cache");
-  common::createDirectories("test_cache");
+  EXPECT_TRUE(common::removeAll("test_cache"));
+  EXPECT_TRUE(common::createDirectories("test_cache"));
 
   ServerConfig server;
   server.SetUrl(ignition::common::URI(
@@ -1139,8 +1143,8 @@ TEST_F(FuelClientTest, CachedWorld)
 {
   // Configure to use binary path as cache and populate it
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
-  common::removeAll("test_cache");
-  common::createDirectories("test_cache");
+  EXPECT_TRUE(common::removeAll("test_cache"));
+  EXPECT_TRUE(common::createDirectories("test_cache"));
   ClientConfig config;
   config.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
   createLocalWorld(config);

--- a/src/FuelClient_TEST.cc
+++ b/src/FuelClient_TEST.cc
@@ -50,9 +50,9 @@ void createLocalModel(ClientConfig &_conf)
   auto modelPath = common::joinPaths(
       "test_cache", "localhost:8007", "alice", "models", "My Model");
 
-  EXPECT_TRUE(common::createDirectories(
+  ASSERT_TRUE(common::createDirectories(
       common::joinPaths(modelPath, "2", "meshes")));
-  EXPECT_TRUE(common::createDirectories(
+  ASSERT_TRUE(common::createDirectories(
       common::joinPaths(modelPath, "3", "meshes")));
 
   {
@@ -62,7 +62,7 @@ void createLocalModel(ClientConfig &_conf)
     fout.flush();
     fout.close();
 
-    EXPECT_TRUE(common::copyFile(common::joinPaths(modelPath, "2",
+    ASSERT_TRUE(common::copyFile(common::joinPaths(modelPath, "2",
         "model.config"), common::joinPaths(modelPath, "3", "model.config")));
   }
 
@@ -73,7 +73,7 @@ void createLocalModel(ClientConfig &_conf)
     fout.flush();
     fout.close();
 
-    EXPECT_TRUE(common::copyFile(common::joinPaths(modelPath, "2", "model.sdf"),
+    ASSERT_TRUE(common::copyFile(common::joinPaths(modelPath, "2", "model.sdf"),
         common::joinPaths(modelPath, "3", "model.sdf")));
   }
 
@@ -84,7 +84,7 @@ void createLocalModel(ClientConfig &_conf)
     fout.flush();
     fout.close();
 
-    EXPECT_TRUE(common::copyFile(common::joinPaths(modelPath, "2", "meshes",
+    ASSERT_TRUE(common::copyFile(common::joinPaths(modelPath, "2", "meshes",
         "model.dae"), common::joinPaths(modelPath, "3", "meshes",
         "model.dae")));
   }
@@ -105,8 +105,8 @@ void createLocalWorld(ClientConfig &_conf)
   auto worldPath = common::joinPaths(
       "test_cache", "localhost:8007", "banana", "worlds", "My World");
 
-  EXPECT_TRUE(common::createDirectories(common::joinPaths(worldPath, "2")));
-  EXPECT_TRUE(common::createDirectories(common::joinPaths(worldPath, "3")));
+  ASSERT_TRUE(common::createDirectories(common::joinPaths(worldPath, "2")));
+  ASSERT_TRUE(common::createDirectories(common::joinPaths(worldPath, "3")));
 
   {
     std::ofstream fout(common::joinPaths(worldPath, "2", "strawberry.world"),
@@ -115,7 +115,7 @@ void createLocalWorld(ClientConfig &_conf)
     fout.flush();
     fout.close();
 
-    EXPECT_TRUE(common::copyFile(common::joinPaths(worldPath, "2",
+    ASSERT_TRUE(common::copyFile(common::joinPaths(worldPath, "2",
         "strawberry.world"), common::joinPaths(worldPath, "3",
         "strawberry.world")));
   }
@@ -403,7 +403,7 @@ TEST_F(FuelClientTest, DownloadModel)
   // Configure to use binary path as cache
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
   common::removeAll("test_cache");
-  EXPECT_TRUE(common::createDirectories("test_cache"));
+  ASSERT_TRUE(common::createDirectories("test_cache"));
   ClientConfig config;
   config.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
 
@@ -602,7 +602,7 @@ TEST_F(FuelClientTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(ModelDependencies))
   // Configure to use binary path as cache
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
   common::removeAll("test_cache");
-  EXPECT_TRUE(common::createDirectories("test_cache"));
+  ASSERT_TRUE(common::createDirectories("test_cache"));
   ClientConfig config;
   config.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
 
@@ -676,7 +676,7 @@ TEST_F(FuelClientTest, CachedModel)
   // Configure to use binary path as cache and populate it
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
   common::removeAll("test_cache");
-  EXPECT_TRUE(common::createDirectories("test_cache"));
+  ASSERT_TRUE(common::createDirectories("test_cache"));
   ClientConfig config;
   config.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
   createLocalModel(config);
@@ -1067,7 +1067,7 @@ TEST_F(FuelClientTest, DownloadWorld)
   // Configure to use binary path as cache
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
   common::removeAll("test_cache");
-  EXPECT_TRUE(common::createDirectories("test_cache"));
+  ASSERT_TRUE(common::createDirectories("test_cache"));
 
   ServerConfig server;
   server.SetUrl(ignition::common::URI(
@@ -1145,7 +1145,7 @@ TEST_F(FuelClientTest, CachedWorld)
   // Configure to use binary path as cache and populate it
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
   common::removeAll("test_cache");
-  EXPECT_TRUE(common::createDirectories("test_cache"));
+  ASSERT_TRUE(common::createDirectories("test_cache"));
   ClientConfig config;
   config.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
   createLocalWorld(config);

--- a/src/FuelClient_TEST.cc
+++ b/src/FuelClient_TEST.cc
@@ -402,7 +402,7 @@ TEST_F(FuelClientTest, DownloadModel)
 {
   // Configure to use binary path as cache
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
-  EXPECT_TRUE(common::removeAll("test_cache"));
+  common::removeAll("test_cache");
   EXPECT_TRUE(common::createDirectories("test_cache"));
   ClientConfig config;
   config.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
@@ -601,7 +601,7 @@ TEST_F(FuelClientTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(ModelDependencies))
 {
   // Configure to use binary path as cache
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
-  EXPECT_TRUE(common::removeAll("test_cache"));
+  common::removeAll("test_cache");
   EXPECT_TRUE(common::createDirectories("test_cache"));
   ClientConfig config;
   config.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
@@ -675,7 +675,7 @@ TEST_F(FuelClientTest, CachedModel)
 {
   // Configure to use binary path as cache and populate it
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
-  EXPECT_TRUE(common::removeAll("test_cache"));
+  common::removeAll("test_cache");
   EXPECT_TRUE(common::createDirectories("test_cache"));
   ClientConfig config;
   config.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
@@ -1066,7 +1066,7 @@ TEST_F(FuelClientTest, DownloadWorld)
 {
   // Configure to use binary path as cache
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
-  EXPECT_TRUE(common::removeAll("test_cache"));
+  common::removeAll("test_cache");
   EXPECT_TRUE(common::createDirectories("test_cache"));
 
   ServerConfig server;
@@ -1144,7 +1144,7 @@ TEST_F(FuelClientTest, CachedWorld)
 {
   // Configure to use binary path as cache and populate it
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
-  EXPECT_TRUE(common::removeAll("test_cache"));
+  common::removeAll("test_cache");
   EXPECT_TRUE(common::createDirectories("test_cache"));
   ClientConfig config;
   config.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));

--- a/src/Interface_TEST.cc
+++ b/src/Interface_TEST.cc
@@ -45,8 +45,8 @@ TEST(Interface, FetchResources)
 
   // Configure to use binary path as cache
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
-  EXPECT_TRUE(common::removeAll("test_cache"));
-  EXPECT_TRUE(common::createDirectories("test_cache"));
+  common::removeAll("test_cache");
+  ASSERT_TRUE(common::createDirectories("test_cache"));
   ClientConfig config;
   config.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
 

--- a/src/Interface_TEST.cc
+++ b/src/Interface_TEST.cc
@@ -45,8 +45,8 @@ TEST(Interface, FetchResources)
 
   // Configure to use binary path as cache
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
-  common::removeAll("test_cache");
-  common::createDirectories("test_cache");
+  EXPECT_TRUE(common::removeAll("test_cache"));
+  EXPECT_TRUE(common::createDirectories("test_cache"));
   ClientConfig config;
   config.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
 

--- a/src/LocalCache_TEST.cc
+++ b/src/LocalCache_TEST.cc
@@ -227,7 +227,7 @@ class LocalCacheTest : public ::testing::Test
 TEST_F(LocalCacheTest, AllModels)
 {
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
-  EXPECT_TRUE(common::removeAll("test_cache"));
+  common::removeAll("test_cache");
   EXPECT_TRUE(common::createDirectories("test_cache"));
   ClientConfig conf;
   conf.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
@@ -255,7 +255,7 @@ TEST_F(LocalCacheTest, AllModels)
 TEST_F(LocalCacheTest, MatchingModels)
 {
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
-  EXPECT_TRUE(common::removeAll("test_cache"));
+  common::removeAll("test_cache");
   EXPECT_TRUE(common::createDirectories("test_cache"));
   ClientConfig conf;
   conf.Clear();
@@ -301,7 +301,7 @@ TEST_F(LocalCacheTest, MatchingModels)
 TEST_F(LocalCacheTest, MatchingModel)
 {
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
-  EXPECT_TRUE(common::removeAll("test_cache"));
+  common::removeAll("test_cache");
   EXPECT_TRUE(common::createDirectories("test_cache"));
   ClientConfig conf;
   conf.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
@@ -357,7 +357,7 @@ TEST_F(LocalCacheTest, MatchingModel)
 TEST_F(LocalCacheTest, AllWorlds)
 {
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
-  EXPECT_TRUE(common::removeAll("test_cache"));
+  common::removeAll("test_cache");
   EXPECT_TRUE(common::createDirectories("test_cache"));
   ClientConfig conf;
   conf.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
@@ -389,7 +389,7 @@ TEST_F(LocalCacheTest, AllWorlds)
 TEST_F(LocalCacheTest, MatchingWorlds)
 {
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
-  EXPECT_TRUE(common::removeAll("test_cache"));
+  common::removeAll("test_cache");
   EXPECT_TRUE(common::createDirectories("test_cache"));
   ClientConfig conf;
   conf.Clear();
@@ -423,8 +423,8 @@ TEST_F(LocalCacheTest, MatchingWorlds)
 TEST_F(LocalCacheTest, MatchingWorld)
 {
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
-  EXPECT_TRUE(common::removeAll("test_cache"));
- EXPECT_TRUE(common::createDirectories("test_cache"));
+  common::removeAll("test_cache");
+  EXPECT_TRUE(common::createDirectories("test_cache"));
   ClientConfig conf;
   conf.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
   createLocal6Worlds(conf);

--- a/src/LocalCache_TEST.cc
+++ b/src/LocalCache_TEST.cc
@@ -47,18 +47,18 @@ void createLocal6Models(ClientConfig &_conf)
   igndbg << "Creating 6 local models in [" << common::cwd() << "]" << std::endl;
 
   auto serverPath = common::joinPaths("test_cache", "localhost:8001");
-  common::createDirectories(common::joinPaths(serverPath,
-      "alice", "models", "am1", "2"));
-  common::createDirectories(common::joinPaths(serverPath,
-      "alice", "models", "am2", "1"));
-  common::createDirectories(common::joinPaths(serverPath,
-      "bob", "models", "bm1", "1"));
-  common::createDirectories(common::joinPaths(serverPath,
-      "bob", "models", "bm2", "2"));
-  common::createDirectories(common::joinPaths(serverPath,
-      "trudy", "models", "tm1", "3"));
-  common::createDirectories(common::joinPaths(serverPath,
-      "trudy", "models", "tm2", "2"));
+  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+      "alice", "models", "am1", "2")));
+  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+      "alice", "models", "am2", "1")));
+  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+      "bob", "models", "bm1", "1")));
+  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+      "bob", "models", "bm2", "2")));
+  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+      "trudy", "models", "tm1", "3")));
+  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+      "trudy", "models", "tm2", "2")));
 
   std::ofstream fout(common::joinPaths(serverPath,
       "alice", "models", "am1", "2", "model.config"),
@@ -67,26 +67,26 @@ void createLocal6Models(ClientConfig &_conf)
   fout.flush();
   fout.close();
 
-  common::copyFile(common::joinPaths(serverPath,
+  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "models", "am1", "2", "model.config"),
       common::joinPaths(serverPath,
-      "alice", "models", "am2", "1", "model.config"));
-  common::copyFile(common::joinPaths(serverPath,
+      "alice", "models", "am2", "1", "model.config")));
+  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "models", "am1", "2", "model.config"),
       common::joinPaths(serverPath,
-      "bob", "models", "bm1", "1", "model.config"));
-  common::copyFile(common::joinPaths(serverPath,
+      "bob", "models", "bm1", "1", "model.config")));
+  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "models", "am1", "2", "model.config"),
       common::joinPaths(serverPath,
-      "bob", "models", "bm2", "2", "model.config"));
-  common::copyFile(common::joinPaths(serverPath,
+      "bob", "models", "bm2", "2", "model.config")));
+  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "models", "am1", "2", "model.config"),
       common::joinPaths(serverPath,
-      "trudy", "models", "tm1", "3", "model.config"));
-  common::copyFile(common::joinPaths(serverPath,
+      "trudy", "models", "tm1", "3", "model.config")));
+  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "models", "am1", "2", "model.config"),
       common::joinPaths(serverPath,
-      "trudy", "models", "tm2", "2", "model.config"));
+      "trudy", "models", "tm2", "2", "model.config")));
 
   ignition::fuel_tools::ServerConfig srv;
   srv.SetUrl(common::URI("http://localhost:8001/"));
@@ -99,12 +99,12 @@ void createLocal3Models(ClientConfig &_conf)
   igndbg << "Creating 3 local models in [" << common::cwd() << "]" << std::endl;
 
   auto serverPath = common::joinPaths("test_cache", "localhost:8007");
-  common::createDirectories(common::joinPaths(serverPath,
-      "alice", "models", "am1", "2"));
-  common::createDirectories(common::joinPaths(serverPath,
-      "bob", "models", "bm1", "1"));
-  common::createDirectories(common::joinPaths(serverPath,
-      "trudy", "models", "tm1", "3"));
+  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+      "alice", "models", "am1", "2")));
+  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+      "bob", "models", "bm1", "1")));
+  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+      "trudy", "models", "tm1", "3")));
 
   std::ofstream fout(common::joinPaths(serverPath,
       "alice", "models", "am1", "2", "model.config"),
@@ -113,14 +113,14 @@ void createLocal3Models(ClientConfig &_conf)
   fout.flush();
   fout.close();
 
-  common::copyFile(common::joinPaths(serverPath,
+  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "models", "am1", "2", "model.config"),
       common::joinPaths(serverPath,
-      "bob", "models", "bm1", "1", "model.config"));
-  common::copyFile(common::joinPaths(serverPath,
+      "bob", "models", "bm1", "1", "model.config")));
+  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "models", "am1", "2", "model.config"),
       common::joinPaths(serverPath,
-      "trudy", "models", "tm1", "3", "model.config"));
+      "trudy", "models", "tm1", "3", "model.config")));
 
   ignition::fuel_tools::ServerConfig srv;
   srv.SetUrl(ignition::common::URI("http://localhost:8007/"));
@@ -133,18 +133,18 @@ void createLocal6Worlds(ClientConfig &_conf)
   igndbg << "Creating 6 local worlds in [" << common::cwd() << "]" << std::endl;
 
   auto serverPath = common::joinPaths("test_cache", "localhost:8001");
-  common::createDirectories(common::joinPaths(serverPath,
-      "alice", "worlds", "am1", "2"));
-  common::createDirectories(common::joinPaths(serverPath,
-      "alice", "worlds", "am2", "1"));
-  common::createDirectories(common::joinPaths(serverPath,
-      "bob", "worlds", "bm1", "1"));
-  common::createDirectories(common::joinPaths(serverPath,
-      "bob", "worlds", "bm2", "2"));
-  common::createDirectories(common::joinPaths(serverPath,
-      "trudy", "worlds", "tm1", "3"));
-  common::createDirectories(common::joinPaths(serverPath,
-      "trudy", "worlds", "tm2", "2"));
+  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+      "alice", "worlds", "am1", "2")));
+  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+      "alice", "worlds", "am2", "1")));
+  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+      "bob", "worlds", "bm1", "1")));
+  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+      "bob", "worlds", "bm2", "2")));
+  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+      "trudy", "worlds", "tm1", "3")));
+  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+      "trudy", "worlds", "tm2", "2")));
 
   std::ofstream fout(common::joinPaths(serverPath,
       "alice", "worlds", "am1", "2", "world.world"),
@@ -153,26 +153,26 @@ void createLocal6Worlds(ClientConfig &_conf)
   fout.flush();
   fout.close();
 
-  common::copyFile(common::joinPaths(serverPath,
+  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "worlds", "am1", "2", "world.world"),
       common::joinPaths(serverPath,
-      "alice", "worlds", "am2", "1", "world.world"));
-  common::copyFile(common::joinPaths(serverPath,
+      "alice", "worlds", "am2", "1", "world.world")));
+  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "worlds", "am1", "2", "world.world"),
       common::joinPaths(serverPath,
-      "bob", "worlds", "bm1", "1", "world.world"));
-  common::copyFile(common::joinPaths(serverPath,
+      "bob", "worlds", "bm1", "1", "world.world")));
+  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "worlds", "am1", "2", "world.world"),
       common::joinPaths(serverPath,
-      "bob", "worlds", "bm2", "2", "world.world"));
-  common::copyFile(common::joinPaths(serverPath,
+      "bob", "worlds", "bm2", "2", "world.world")));
+  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "worlds", "am1", "2", "world.world"),
       common::joinPaths(serverPath,
-      "trudy", "worlds", "tm1", "3", "world.world"));
-  common::copyFile(common::joinPaths(serverPath,
+      "trudy", "worlds", "tm1", "3", "world.world")));
+  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "worlds", "am1", "2", "world.world"),
       common::joinPaths(serverPath,
-      "trudy", "worlds", "tm2", "2", "world.world"));
+      "trudy", "worlds", "tm2", "2", "world.world")));
 
   ignition::fuel_tools::ServerConfig srv;
   srv.SetUrl(ignition::common::URI("http://localhost:8001/"));
@@ -185,12 +185,12 @@ void createLocal3Worlds(ClientConfig &_conf)
   igndbg << "Creating 3 local worlds in [" << common::cwd() << "]" << std::endl;
 
   auto serverPath = common::joinPaths("test_cache", "localhost:8007");
-  common::createDirectories(common::joinPaths(serverPath,
-      "alice", "worlds", "am1", "2"));
-  common::createDirectories(common::joinPaths(serverPath,
-      "bob", "worlds", "bm1", "1"));
-  common::createDirectories(common::joinPaths(serverPath,
-      "trudy", "worlds", "tm1", "3"));
+  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+      "alice", "worlds", "am1", "2")));
+  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+      "bob", "worlds", "bm1", "1")));
+  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+      "trudy", "worlds", "tm1", "3")));
 
   std::ofstream fout(common::joinPaths(serverPath,
       "alice", "worlds", "am1", "2", "world.world"),
@@ -199,14 +199,14 @@ void createLocal3Worlds(ClientConfig &_conf)
   fout.flush();
   fout.close();
 
-  common::copyFile(common::joinPaths(serverPath,
+  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "worlds", "am1", "2", "world.world"),
       common::joinPaths(serverPath,
-      "bob", "worlds", "bm1", "1", "world.world"));
-  common::copyFile(common::joinPaths(serverPath,
+      "bob", "worlds", "bm1", "1", "world.world")));
+  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "worlds", "am1", "2", "world.world"),
       common::joinPaths(serverPath,
-      "trudy", "worlds", "tm1", "3", "world.world"));
+      "trudy", "worlds", "tm1", "3", "world.world")));
 
   ignition::fuel_tools::ServerConfig srv;
   srv.SetUrl(common::URI("http://localhost:8007/"));
@@ -224,13 +224,11 @@ class LocalCacheTest : public ::testing::Test
 
 /////////////////////////////////////////////////
 /// \brief Iterate through all models in cache
-// Windows doesn't support colons in filenames
-// https://github.com/ignitionrobotics/ign-fuel-tools/issues/106
 TEST_F(LocalCacheTest, AllModels)
 {
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
-  common::removeAll("test_cache");
-  common::createDirectories("test_cache");
+  EXPECT_TRUE(common::removeAll("test_cache"));
+  EXPECT_TRUE(common::createDirectories("test_cache"));
   ClientConfig conf;
   conf.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
   createLocal6Models(conf);
@@ -254,13 +252,11 @@ TEST_F(LocalCacheTest, AllModels)
 /////////////////////////////////////////////////
 /// \brief Get all models that match some fields
 /// \brief Iterate through all models in cache
-// Windows doesn't support colons in filenames
-// https://github.com/ignitionrobotics/ign-fuel-tools/issues/106
 TEST_F(LocalCacheTest, MatchingModels)
 {
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
-  common::removeAll("test_cache");
-  common::createDirectories("test_cache");
+  EXPECT_TRUE(common::removeAll("test_cache"));
+  EXPECT_TRUE(common::createDirectories("test_cache"));
   ClientConfig conf;
   conf.Clear();
   conf.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
@@ -302,13 +298,11 @@ TEST_F(LocalCacheTest, MatchingModels)
 /////////////////////////////////////////////////
 /// \brief Get a specific model from cache
 /// \brief Iterate through all models in cache
-// Windows doesn't support colons in filenames
-// https://github.com/ignitionrobotics/ign-fuel-tools/issues/106
 TEST_F(LocalCacheTest, MatchingModel)
 {
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
-  common::removeAll("test_cache");
-  common::createDirectories("test_cache");
+  EXPECT_TRUE(common::removeAll("test_cache"));
+  EXPECT_TRUE(common::createDirectories("test_cache"));
   ClientConfig conf;
   conf.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
   createLocal6Models(conf);
@@ -360,13 +354,11 @@ TEST_F(LocalCacheTest, MatchingModel)
 /////////////////////////////////////////////////
 /// \brief Iterate through all worlds in cache
 /// \brief Iterate through all models in cache
-// Windows doesn't support colons in filenames
-// https://github.com/ignitionrobotics/ign-fuel-tools/issues/106
 TEST_F(LocalCacheTest, AllWorlds)
 {
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
-  common::removeAll("test_cache");
-  common::createDirectories("test_cache");
+  EXPECT_TRUE(common::removeAll("test_cache"));
+  EXPECT_TRUE(common::createDirectories("test_cache"));
   ClientConfig conf;
   conf.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
   createLocal6Worlds(conf);
@@ -394,13 +386,11 @@ TEST_F(LocalCacheTest, AllWorlds)
 /////////////////////////////////////////////////
 /// \brief Get all worlds that match some fields
 /// \brief Iterate through all models in cache
-// Windows doesn't support colons in filenames
-// https://github.com/ignitionrobotics/ign-fuel-tools/issues/106
 TEST_F(LocalCacheTest, MatchingWorlds)
 {
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
-  common::removeAll("test_cache");
-  common::createDirectories("test_cache");
+  EXPECT_TRUE(common::removeAll("test_cache"));
+  EXPECT_TRUE(common::createDirectories("test_cache"));
   ClientConfig conf;
   conf.Clear();
   conf.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
@@ -430,13 +420,11 @@ TEST_F(LocalCacheTest, MatchingWorlds)
 /////////////////////////////////////////////////
 /// \brief Get a specific world from cache
 /// \brief Iterate through all models in cache
-// Windows doesn't support colons in filenames
-// https://github.com/ignitionrobotics/ign-fuel-tools/issues/106
 TEST_F(LocalCacheTest, MatchingWorld)
 {
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
-  common::removeAll("test_cache");
-  common::createDirectories("test_cache");
+  EXPECT_TRUE(common::removeAll("test_cache"));
+ EXPECT_TRUE(common::createDirectories("test_cache"));
   ClientConfig conf;
   conf.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
   createLocal6Worlds(conf);

--- a/src/LocalCache_TEST.cc
+++ b/src/LocalCache_TEST.cc
@@ -47,17 +47,17 @@ void createLocal6Models(ClientConfig &_conf)
   igndbg << "Creating 6 local models in [" << common::cwd() << "]" << std::endl;
 
   auto serverPath = common::joinPaths("test_cache", "localhost:8001");
-  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::createDirectories(common::joinPaths(serverPath,
       "alice", "models", "am1", "2")));
-  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::createDirectories(common::joinPaths(serverPath,
       "alice", "models", "am2", "1")));
-  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::createDirectories(common::joinPaths(serverPath,
       "bob", "models", "bm1", "1")));
-  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::createDirectories(common::joinPaths(serverPath,
       "bob", "models", "bm2", "2")));
-  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::createDirectories(common::joinPaths(serverPath,
       "trudy", "models", "tm1", "3")));
-  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::createDirectories(common::joinPaths(serverPath,
       "trudy", "models", "tm2", "2")));
 
   std::ofstream fout(common::joinPaths(serverPath,
@@ -67,23 +67,23 @@ void createLocal6Models(ClientConfig &_conf)
   fout.flush();
   fout.close();
 
-  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "models", "am1", "2", "model.config"),
       common::joinPaths(serverPath,
       "alice", "models", "am2", "1", "model.config")));
-  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "models", "am1", "2", "model.config"),
       common::joinPaths(serverPath,
       "bob", "models", "bm1", "1", "model.config")));
-  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "models", "am1", "2", "model.config"),
       common::joinPaths(serverPath,
       "bob", "models", "bm2", "2", "model.config")));
-  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "models", "am1", "2", "model.config"),
       common::joinPaths(serverPath,
       "trudy", "models", "tm1", "3", "model.config")));
-  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "models", "am1", "2", "model.config"),
       common::joinPaths(serverPath,
       "trudy", "models", "tm2", "2", "model.config")));
@@ -99,11 +99,11 @@ void createLocal3Models(ClientConfig &_conf)
   igndbg << "Creating 3 local models in [" << common::cwd() << "]" << std::endl;
 
   auto serverPath = common::joinPaths("test_cache", "localhost:8007");
-  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::createDirectories(common::joinPaths(serverPath,
       "alice", "models", "am1", "2")));
-  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::createDirectories(common::joinPaths(serverPath,
       "bob", "models", "bm1", "1")));
-  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::createDirectories(common::joinPaths(serverPath,
       "trudy", "models", "tm1", "3")));
 
   std::ofstream fout(common::joinPaths(serverPath,
@@ -113,11 +113,11 @@ void createLocal3Models(ClientConfig &_conf)
   fout.flush();
   fout.close();
 
-  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "models", "am1", "2", "model.config"),
       common::joinPaths(serverPath,
       "bob", "models", "bm1", "1", "model.config")));
-  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "models", "am1", "2", "model.config"),
       common::joinPaths(serverPath,
       "trudy", "models", "tm1", "3", "model.config")));
@@ -133,17 +133,17 @@ void createLocal6Worlds(ClientConfig &_conf)
   igndbg << "Creating 6 local worlds in [" << common::cwd() << "]" << std::endl;
 
   auto serverPath = common::joinPaths("test_cache", "localhost:8001");
-  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::createDirectories(common::joinPaths(serverPath,
       "alice", "worlds", "am1", "2")));
-  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::createDirectories(common::joinPaths(serverPath,
       "alice", "worlds", "am2", "1")));
-  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::createDirectories(common::joinPaths(serverPath,
       "bob", "worlds", "bm1", "1")));
-  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::createDirectories(common::joinPaths(serverPath,
       "bob", "worlds", "bm2", "2")));
-  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::createDirectories(common::joinPaths(serverPath,
       "trudy", "worlds", "tm1", "3")));
-  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::createDirectories(common::joinPaths(serverPath,
       "trudy", "worlds", "tm2", "2")));
 
   std::ofstream fout(common::joinPaths(serverPath,
@@ -153,23 +153,23 @@ void createLocal6Worlds(ClientConfig &_conf)
   fout.flush();
   fout.close();
 
-  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "worlds", "am1", "2", "world.world"),
       common::joinPaths(serverPath,
       "alice", "worlds", "am2", "1", "world.world")));
-  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "worlds", "am1", "2", "world.world"),
       common::joinPaths(serverPath,
       "bob", "worlds", "bm1", "1", "world.world")));
-  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "worlds", "am1", "2", "world.world"),
       common::joinPaths(serverPath,
       "bob", "worlds", "bm2", "2", "world.world")));
-  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "worlds", "am1", "2", "world.world"),
       common::joinPaths(serverPath,
       "trudy", "worlds", "tm1", "3", "world.world")));
-  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "worlds", "am1", "2", "world.world"),
       common::joinPaths(serverPath,
       "trudy", "worlds", "tm2", "2", "world.world")));
@@ -185,11 +185,11 @@ void createLocal3Worlds(ClientConfig &_conf)
   igndbg << "Creating 3 local worlds in [" << common::cwd() << "]" << std::endl;
 
   auto serverPath = common::joinPaths("test_cache", "localhost:8007");
-  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::createDirectories(common::joinPaths(serverPath,
       "alice", "worlds", "am1", "2")));
-  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::createDirectories(common::joinPaths(serverPath,
       "bob", "worlds", "bm1", "1")));
-  EXPECT_TRUE(common::createDirectories(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::createDirectories(common::joinPaths(serverPath,
       "trudy", "worlds", "tm1", "3")));
 
   std::ofstream fout(common::joinPaths(serverPath,
@@ -199,11 +199,11 @@ void createLocal3Worlds(ClientConfig &_conf)
   fout.flush();
   fout.close();
 
-  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "worlds", "am1", "2", "world.world"),
       common::joinPaths(serverPath,
       "bob", "worlds", "bm1", "1", "world.world")));
-  EXPECT_TRUE(common::copyFile(common::joinPaths(serverPath,
+  ASSERT_TRUE(common::copyFile(common::joinPaths(serverPath,
       "alice", "worlds", "am1", "2", "world.world"),
       common::joinPaths(serverPath,
       "trudy", "worlds", "tm1", "3", "world.world")));
@@ -228,7 +228,7 @@ TEST_F(LocalCacheTest, AllModels)
 {
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
   common::removeAll("test_cache");
-  EXPECT_TRUE(common::createDirectories("test_cache"));
+  ASSERT_TRUE(common::createDirectories("test_cache"));
   ClientConfig conf;
   conf.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
   createLocal6Models(conf);
@@ -256,7 +256,7 @@ TEST_F(LocalCacheTest, MatchingModels)
 {
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
   common::removeAll("test_cache");
-  EXPECT_TRUE(common::createDirectories("test_cache"));
+  ASSERT_TRUE(common::createDirectories("test_cache"));
   ClientConfig conf;
   conf.Clear();
   conf.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
@@ -302,7 +302,7 @@ TEST_F(LocalCacheTest, MatchingModel)
 {
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
   common::removeAll("test_cache");
-  EXPECT_TRUE(common::createDirectories("test_cache"));
+  ASSERT_TRUE(common::createDirectories("test_cache"));
   ClientConfig conf;
   conf.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
   createLocal6Models(conf);
@@ -358,7 +358,7 @@ TEST_F(LocalCacheTest, AllWorlds)
 {
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
   common::removeAll("test_cache");
-  EXPECT_TRUE(common::createDirectories("test_cache"));
+  ASSERT_TRUE(common::createDirectories("test_cache"));
   ClientConfig conf;
   conf.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
   createLocal6Worlds(conf);
@@ -390,7 +390,7 @@ TEST_F(LocalCacheTest, MatchingWorlds)
 {
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
   common::removeAll("test_cache");
-  EXPECT_TRUE(common::createDirectories("test_cache"));
+  ASSERT_TRUE(common::createDirectories("test_cache"));
   ClientConfig conf;
   conf.Clear();
   conf.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
@@ -424,7 +424,7 @@ TEST_F(LocalCacheTest, MatchingWorld)
 {
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
   common::removeAll("test_cache");
-  EXPECT_TRUE(common::createDirectories("test_cache"));
+  ASSERT_TRUE(common::createDirectories("test_cache"));
   ClientConfig conf;
   conf.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
   createLocal6Worlds(conf);

--- a/src/ign_src_TEST.cc
+++ b/src/ign_src_TEST.cc
@@ -202,7 +202,7 @@ TEST(CmdLine, ModelDownloadUnversioned)
 {
   cmdVerbosity("4");
 
-  EXPECT_TRUE(common::removeAll("test_cache"));
+  common::removeAll("test_cache");
   EXPECT_TRUE(common::createDirectories("test_cache"));
   setenv("IGN_FUEL_CACHE_PATH", "test_cache", true);
 
@@ -240,7 +240,7 @@ TEST(CmdLine, DownloadConfigCache)
   cmdVerbosity("4");
 
   unsetenv("IGN_FUEL_CACHE_PATH");
-  EXPECT_TRUE(common::removeAll("test_cache"));
+  common::removeAll("test_cache");
   EXPECT_TRUE(common::createDirectories("test_cache"));
 
   // Test config
@@ -428,7 +428,7 @@ TEST(FuelClientTest, WorldDownloadUnversioned)
 {
   cmdVerbosity("4");
 
-  EXPECT_TRUE(common::removeAll("test_cache"));
+  common::removeAll("test_cache");
   EXPECT_TRUE(common::createDirectories("test_cache"));
   setenv("IGN_FUEL_CACHE_PATH", "test_cache", true);
 
@@ -475,7 +475,7 @@ TEST_P(DownloadCollectionTest, AllItems)
 {
   cmdVerbosity("4");
 
-  EXPECT_TRUE(common::removeAll("test_cache"));
+  common::removeAll("test_cache");
   EXPECT_TRUE(common::createDirectories("test_cache"));
   setenv("IGN_FUEL_CACHE_PATH", "test_cache", true);
 
@@ -551,7 +551,7 @@ TEST_P(DownloadCollectionTest, Models)
 {
   cmdVerbosity("4");
 
-  EXPECT_TRUE(common::removeAll("test_cache"));
+  common::removeAll("test_cache");
   EXPECT_TRUE(common::createDirectories("test_cache"));
   setenv("IGN_FUEL_CACHE_PATH", "test_cache", true);
 
@@ -614,7 +614,7 @@ TEST_P(DownloadCollectionTest, Worlds)
 {
   cmdVerbosity("4");
 
-  EXPECT_TRUE(common::removeAll("test_cache"));
+  common::removeAll("test_cache");
   EXPECT_TRUE(common::createDirectories("test_cache"));
   setenv("IGN_FUEL_CACHE_PATH", "test_cache", true);
 

--- a/src/ign_src_TEST.cc
+++ b/src/ign_src_TEST.cc
@@ -203,7 +203,7 @@ TEST(CmdLine, ModelDownloadUnversioned)
   cmdVerbosity("4");
 
   common::removeAll("test_cache");
-  EXPECT_TRUE(common::createDirectories("test_cache"));
+  ASSERT_TRUE(common::createDirectories("test_cache"));
   setenv("IGN_FUEL_CACHE_PATH", "test_cache", true);
 
   std::stringstream stdOutBuffer;
@@ -241,7 +241,7 @@ TEST(CmdLine, DownloadConfigCache)
 
   unsetenv("IGN_FUEL_CACHE_PATH");
   common::removeAll("test_cache");
-  EXPECT_TRUE(common::createDirectories("test_cache"));
+  ASSERT_TRUE(common::createDirectories("test_cache"));
 
   // Test config
   std::ofstream ofs;
@@ -429,7 +429,7 @@ TEST(FuelClientTest, WorldDownloadUnversioned)
   cmdVerbosity("4");
 
   common::removeAll("test_cache");
-  EXPECT_TRUE(common::createDirectories("test_cache"));
+  ASSERT_TRUE(common::createDirectories("test_cache"));
   setenv("IGN_FUEL_CACHE_PATH", "test_cache", true);
 
   std::stringstream stdOutBuffer;
@@ -476,7 +476,7 @@ TEST_P(DownloadCollectionTest, AllItems)
   cmdVerbosity("4");
 
   common::removeAll("test_cache");
-  EXPECT_TRUE(common::createDirectories("test_cache"));
+  ASSERT_TRUE(common::createDirectories("test_cache"));
   setenv("IGN_FUEL_CACHE_PATH", "test_cache", true);
 
   std::stringstream stdOutBuffer;
@@ -552,7 +552,7 @@ TEST_P(DownloadCollectionTest, Models)
   cmdVerbosity("4");
 
   common::removeAll("test_cache");
-  EXPECT_TRUE(common::createDirectories("test_cache"));
+  ASSERT_TRUE(common::createDirectories("test_cache"));
   setenv("IGN_FUEL_CACHE_PATH", "test_cache", true);
 
   std::stringstream stdOutBuffer;
@@ -615,7 +615,7 @@ TEST_P(DownloadCollectionTest, Worlds)
   cmdVerbosity("4");
 
   common::removeAll("test_cache");
-  EXPECT_TRUE(common::createDirectories("test_cache"));
+  ASSERT_TRUE(common::createDirectories("test_cache"));
   setenv("IGN_FUEL_CACHE_PATH", "test_cache", true);
 
   std::stringstream stdOutBuffer;

--- a/src/ign_src_TEST.cc
+++ b/src/ign_src_TEST.cc
@@ -202,8 +202,8 @@ TEST(CmdLine, ModelDownloadUnversioned)
 {
   cmdVerbosity("4");
 
-  ignition::common::removeAll("test_cache");
-  ignition::common::createDirectories("test_cache");
+  EXPECT_TRUE(common::removeAll("test_cache"));
+  EXPECT_TRUE(common::createDirectories("test_cache"));
   setenv("IGN_FUEL_CACHE_PATH", "test_cache", true);
 
   std::stringstream stdOutBuffer;
@@ -220,11 +220,11 @@ TEST(CmdLine, ModelDownloadUnversioned)
   EXPECT_TRUE(stdErrBuffer.str().empty()) << stdErrBuffer.str();
 
   // Check files
-  EXPECT_TRUE(ignition::common::isDirectory(
+  EXPECT_TRUE(common::isDirectory(
       "test_cache/fuel.ignitionrobotics.org/chapulina/models/test box"));
-  EXPECT_TRUE(ignition::common::isDirectory(
+  EXPECT_TRUE(common::isDirectory(
       "test_cache/fuel.ignitionrobotics.org/chapulina/models/test box/2"));
-  EXPECT_TRUE(ignition::common::isFile(
+  EXPECT_TRUE(common::isFile(
       std::string("test_cache/fuel.ignitionrobotics.org/chapulina/models") +
       "/test box/2/model.sdf"));
 
@@ -240,8 +240,8 @@ TEST(CmdLine, DownloadConfigCache)
   cmdVerbosity("4");
 
   unsetenv("IGN_FUEL_CACHE_PATH");
-  ignition::common::removeAll("test_cache");
-  ignition::common::createDirectories("test_cache");
+  EXPECT_TRUE(common::removeAll("test_cache"));
+  EXPECT_TRUE(common::createDirectories("test_cache"));
 
   // Test config
   std::ofstream ofs;
@@ -277,9 +277,9 @@ TEST(CmdLine, DownloadConfigCache)
   auto modelPath = common::joinPaths(std::string(PROJECT_BINARY_PATH),
       "test_cache", "fuel.ignitionrobotics.org", "chapulina", "models",
       "test box");
-  EXPECT_TRUE(ignition::common::isDirectory(modelPath));
-  EXPECT_TRUE(ignition::common::isDirectory(common::joinPaths(modelPath, "2")));
-  EXPECT_TRUE(ignition::common::isFile(common::joinPaths(modelPath, "2",
+  EXPECT_TRUE(common::isDirectory(modelPath));
+  EXPECT_TRUE(common::isDirectory(common::joinPaths(modelPath, "2")));
+  EXPECT_TRUE(common::isFile(common::joinPaths(modelPath, "2",
       "model.sdf")));
 
   clearIOStreams(stdOutBuffer, stdErrBuffer);
@@ -428,8 +428,8 @@ TEST(FuelClientTest, WorldDownloadUnversioned)
 {
   cmdVerbosity("4");
 
-  ignition::common::removeAll("test_cache");
-  ignition::common::createDirectories("test_cache");
+  EXPECT_TRUE(common::removeAll("test_cache"));
+  EXPECT_TRUE(common::createDirectories("test_cache"));
   setenv("IGN_FUEL_CACHE_PATH", "test_cache", true);
 
   std::stringstream stdOutBuffer;
@@ -446,14 +446,14 @@ TEST(FuelClientTest, WorldDownloadUnversioned)
   EXPECT_TRUE(stdErrBuffer.str().empty());
 
   // Check files
-  EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_TRUE(common::isDirectory(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world")));
-  EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_TRUE(common::isDirectory(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world", "2")));
-  EXPECT_TRUE(ignition::common::isFile(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_TRUE(common::isFile(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world", "2", "test.world")));
 
   clearIOStreams(stdOutBuffer, stdErrBuffer);
@@ -475,8 +475,8 @@ TEST_P(DownloadCollectionTest, AllItems)
 {
   cmdVerbosity("4");
 
-  ignition::common::removeAll("test_cache");
-  ignition::common::createDirectories("test_cache");
+  EXPECT_TRUE(common::removeAll("test_cache"));
+  EXPECT_TRUE(common::createDirectories("test_cache"));
   setenv("IGN_FUEL_CACHE_PATH", "test_cache", true);
 
   std::stringstream stdOutBuffer;
@@ -497,47 +497,47 @@ TEST_P(DownloadCollectionTest, AllItems)
 
   // Check files
   // Model: Backpack
-  EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_TRUE(common::isDirectory(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "models", "backpack")));
-  EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_TRUE(common::isDirectory(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "models", "backpack", "2")));
-  EXPECT_TRUE(ignition::common::isFile(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_TRUE(common::isFile(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "models", "backpack", "2", "model.sdf")));
 
   // Model: TEAMBASE
-  EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_TRUE(common::isDirectory(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "models", "teambase")));
-  EXPECT_TRUE(ignition::common::isDirectory(
-     ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_TRUE(common::isDirectory(
+     common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "models", "teambase", "2")));
-  EXPECT_TRUE(ignition::common::isFile(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_TRUE(common::isFile(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
      "openrobotics", "models", "teambase", "2", "model.sdf")));
 
   // World: Test World
-  EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_TRUE(common::isDirectory(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world")));
-  EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_TRUE(common::isDirectory(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world", "2")));
-  EXPECT_TRUE(ignition::common::isFile(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_TRUE(common::isFile(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world", "2", "test.world")));
 
   // World: Test World 2
-  EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_TRUE(common::isDirectory(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world 2")));
-  EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_TRUE(common::isDirectory(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world 2", "2")));
-  EXPECT_TRUE(ignition::common::isFile(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_TRUE(common::isFile(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world 2", "2", "test.world")));
   clearIOStreams(stdOutBuffer, stdErrBuffer);
   restoreIO();
@@ -551,8 +551,8 @@ TEST_P(DownloadCollectionTest, Models)
 {
   cmdVerbosity("4");
 
-  ignition::common::removeAll("test_cache");
-  ignition::common::createDirectories("test_cache");
+  EXPECT_TRUE(common::removeAll("test_cache"));
+  EXPECT_TRUE(common::createDirectories("test_cache"));
   setenv("IGN_FUEL_CACHE_PATH", "test_cache", true);
 
   std::stringstream stdOutBuffer;
@@ -572,35 +572,35 @@ TEST_P(DownloadCollectionTest, Models)
 
   // Check files
   // Model: Backpack
-  EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_TRUE(common::isDirectory(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "models", "backpack")));
-  EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_TRUE(common::isDirectory(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "models", "backpack", "2")));
-  EXPECT_TRUE(ignition::common::isFile(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_TRUE(common::isFile(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "models", "backpack", "2", "model.sdf")));
 
   // Model: TEAMBASE
-  EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_TRUE(common::isDirectory(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "models", "teambase")));
-  EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_TRUE(common::isDirectory(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "models", "teambase", "2")));
-  EXPECT_TRUE(ignition::common::isFile(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_TRUE(common::isFile(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "models", "teambase", "2", "model.sdf")));
 
   // World: Test World
-  EXPECT_FALSE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_FALSE(common::isDirectory(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world")));
 
   // World: Test World 2
-  EXPECT_FALSE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_FALSE(common::isDirectory(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world2")));
   clearIOStreams(stdOutBuffer, stdErrBuffer);
   restoreIO();
@@ -614,8 +614,8 @@ TEST_P(DownloadCollectionTest, Worlds)
 {
   cmdVerbosity("4");
 
-  ignition::common::removeAll("test_cache");
-  ignition::common::createDirectories("test_cache");
+  EXPECT_TRUE(common::removeAll("test_cache"));
+  EXPECT_TRUE(common::createDirectories("test_cache"));
   setenv("IGN_FUEL_CACHE_PATH", "test_cache", true);
 
   std::stringstream stdOutBuffer;
@@ -636,35 +636,35 @@ TEST_P(DownloadCollectionTest, Worlds)
 
   // Check files
   // Model: Backpack
-  EXPECT_FALSE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_FALSE(common::isDirectory(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "models", "backpack")));
 
   // Model: TEAMBASE
-  EXPECT_FALSE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_FALSE(common::isDirectory(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "models", "teambase")));
 
   // World: Test World
-  EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_TRUE(common::isDirectory(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world")));
-  EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_TRUE(common::isDirectory(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world", "2")));
-  EXPECT_TRUE(ignition::common::isFile(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_TRUE(common::isFile(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world", "2", "test.world")));
 
   // World: Test World 2
-  EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_TRUE(common::isDirectory(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world 2")));
-  EXPECT_TRUE(ignition::common::isDirectory(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_TRUE(common::isDirectory(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world 2", "2")));
-  EXPECT_TRUE(ignition::common::isFile(
-    ignition::common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+  EXPECT_TRUE(common::isFile(
+    common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
       "openrobotics", "worlds", "test world 2", "2", "test.world")));
   clearIOStreams(stdOutBuffer, stdErrBuffer);
   restoreIO();


### PR DESCRIPTION
# 🎉 New feature

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

These checks are useful when debugging test failures. At a minimum, they allow us to rule-out these lines are reasons for the failure.

The changes consist in expecting true for these calls:

* `createDirectories`
* `copyFile`

This is motivated by debugging #224 

## Test it
<!--Explain how reviewers can test this new feature manually.-->

CI should pass for all platforms

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
