### PR TITLE
Remove deprecated functions from fuel_tools8

### DIFF
--- a/include/ignition/fuel_tools/FuelClient.hh
+++ b/include/ignition/fuel_tools/FuelClient.hh
@@ -60,18 +60,6 @@ namespace ignition
       public: FuelClient(const ClientConfig &_config,
                          const Rest &_rest = Rest());
 
-      /// \brief Constructor accepts server and auth configuration
-      /// \param[in] _config configuration about servers to connect to
-      /// \param[in] _rest A REST request.
-      /// \param[in] _cache Test hook. Pointer to a local cache. The FuelClient
-      ///            will take ownership of the pointer and free it when
-      ///            destructed. If set to nullptr the client will instantiate
-      ///            it's own cache.
-      /// \remarks the client saves a copy of the config passed into it
-      public: IGN_DEPRECATED(6) FuelClient(const ClientConfig &_config,
-                                           const Rest &_rest,
-                                           LocalCache *_cache);
-
       /// \brief Destructor
       public: ~FuelClient();
 
@@ -203,11 +191,6 @@ namespace ignition
                                  const std::vector<std::string> &_headers,
                                  bool _private,
                                  const std::string &_owner);
-
-      /// \brief Remove a model from ignition fuel
-      /// \param[in] _id The model identifier.
-      /// \return Result of the delete operation
-      public: Result IGN_DEPRECATED(6) DeleteModel(const ModelIdentifier &_id);
 
       /// \brief Remove a resource, such as a model or world, from Ignition Fuel
       /// \param[in] _uri The full URI of the resource, e.g:

--- a/src/FuelClient.cc
+++ b/src/FuelClient.cc
@@ -42,11 +42,12 @@
 #include "ignition/fuel_tools/FuelClient.hh"
 #include "ignition/fuel_tools/Helpers.hh"
 #include "ignition/fuel_tools/JSONParser.hh"
-#include "ignition/fuel_tools/LocalCache.hh"
 #include "ignition/fuel_tools/ModelIdentifier.hh"
-#include "ModelIterPrivate.hh"
 #include "ignition/fuel_tools/RestClient.hh"
 #include "ignition/fuel_tools/WorldIdentifier.hh"
+
+#include "LocalCache.hh"
+#include "ModelIterPrivate.hh"
 #include "WorldIterPrivate.hh"
 
 using namespace ignition;
@@ -240,19 +241,7 @@ FuelClient::FuelClient(const ClientConfig &_config, const Rest &_rest)
   this->dataPtr->rest = _rest;
   this->dataPtr->rest.SetUserAgent(this->dataPtr->config.UserAgent());
 
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#else
-# pragma warning(push)
-# pragma warning(disable: 4996)
-#endif
   this->dataPtr->cache = std::make_unique<LocalCache>(&(this->dataPtr->config));
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#else
-# pragma warning(pop)
-#endif
 
   this->dataPtr->urlModelRegex.reset(new std::regex(
     this->dataPtr->kModelUrlRegexStr));
@@ -264,14 +253,6 @@ FuelClient::FuelClient(const ClientConfig &_config, const Rest &_rest)
     this->dataPtr->kWorldFileUrlRegexStr));
   this->dataPtr->urlCollectionRegex.reset(new std::regex(
     this->dataPtr->kCollectionUrlRegexStr));
-}
-
-//////////////////////////////////////////////////
-FuelClient::FuelClient(const ClientConfig &_config, const Rest &_rest,
-      LocalCache *_cache) : FuelClient(_config, _rest)
-{
-  if (_cache != nullptr)
-    this->dataPtr->cache.reset(_cache);
 }
 
 //////////////////////////////////////////////////
@@ -529,14 +510,6 @@ Result FuelClient::UploadModel(const std::string &_pathToModelDir,
 }
 
 //////////////////////////////////////////////////
-Result FuelClient::DeleteModel(const ModelIdentifier &)
-{
-  ignerr << "Model deletion requires a private-token or JWT to be specified"
-    << " in a header. No action is performed.\n";
-
-  return Result(ResultType::DELETE_ERROR);
-}
-
 void FuelClient::AddServerConfigParametersToHeaders(
   const ignition::fuel_tools::ServerConfig &_serverConfig,
   std::vector<std::string> &_headers) const

--- a/src/FuelClient_TEST.cc
+++ b/src/FuelClient_TEST.cc
@@ -1344,23 +1344,6 @@ TEST_F(FuelClientTest, DownloadWorldFail)
 }
 
 /////////////////////////////////////////////////
-TEST_F(FuelClientTest, DeleteModelFail)
-{
-  FuelClient client;
-  ModelIdentifier modelId;
-
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-  Result result = client.DeleteModel(modelId);
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
-  EXPECT_EQ(ResultType::DELETE_ERROR, result.Type());
-}
-
-/////////////////////////////////////////////////
 TEST_F(FuelClientTest, UploadModelFail)
 {
   FuelClient client;

--- a/src/LocalCache.cc
+++ b/src/LocalCache.cc
@@ -36,12 +36,12 @@
 
 #include "ignition/fuel_tools/ClientConfig.hh"
 #include "ignition/fuel_tools/Helpers.hh"
-#include "ignition/fuel_tools/LocalCache.hh"
 #include "ignition/fuel_tools/Zip.hh"
 
 #include "ModelPrivate.hh"
 #include "ModelIterPrivate.hh"
 #include "WorldIterPrivate.hh"
+#include "LocalCache.hh"
 
 using namespace ignition;
 using namespace fuel_tools;

--- a/src/LocalCache.hh
+++ b/src/LocalCache.hh
@@ -47,8 +47,7 @@ namespace ignition
     {
       /// \brief Constructor
       /// \param[in] _config The configuration for the client
-      public:
-        explicit IGN_DEPRECATED(5) LocalCache(const ClientConfig *_config);
+      public: explicit LocalCache(const ClientConfig *_config);
 
       /// \brief destructor
       public: virtual ~LocalCache();

--- a/src/LocalCache_TEST.cc
+++ b/src/LocalCache_TEST.cc
@@ -25,9 +25,9 @@
 #include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/fuel_tools/ClientConfig.hh"
-#include "ignition/fuel_tools/LocalCache.hh"
 #include "ignition/fuel_tools/WorldIdentifier.hh"
 
+#include "LocalCache.hh"
 #include "test/test_config.h"
 
 #ifdef _WIN32
@@ -236,14 +236,7 @@ TEST_F(LocalCacheTest, AllModels)
   createLocal6Models(conf);
   createLocal3Models(conf);
 
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
   ignition::fuel_tools::LocalCache cache(&conf);
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
 
   auto iter = cache.AllModels();
   std::set<std::string> uniqueNames;
@@ -274,14 +267,7 @@ TEST_F(LocalCacheTest, MatchingModels)
   createLocal6Models(conf);
   createLocal3Models(conf);
 
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
   ignition::fuel_tools::LocalCache cache(&conf);
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
 
   ModelIdentifier am1;
   am1.SetServer(conf.Servers().front());
@@ -327,15 +313,7 @@ TEST_F(LocalCacheTest, MatchingModel)
   conf.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
   createLocal6Models(conf);
 
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
   ignition::fuel_tools::LocalCache cache(&conf);
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
-
 
   ignition::fuel_tools::ServerConfig srv1;
   srv1.SetUrl(common::URI("http://localhost:8001/"));
@@ -394,15 +372,7 @@ TEST_F(LocalCacheTest, AllWorlds)
   createLocal6Worlds(conf);
   createLocal3Worlds(conf);
 
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
   ignition::fuel_tools::LocalCache cache(&conf);
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
-
 
   auto iter = cache.AllWorlds();
   std::set<std::string> uniqueNames;
@@ -437,15 +407,7 @@ TEST_F(LocalCacheTest, MatchingWorlds)
   createLocal6Worlds(conf);
   createLocal3Worlds(conf);
 
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
   ignition::fuel_tools::LocalCache cache(&conf);
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
-
 
   WorldIdentifier am1;
   am1.SetServer(conf.Servers().front());
@@ -479,15 +441,7 @@ TEST_F(LocalCacheTest, MatchingWorld)
   conf.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
   createLocal6Worlds(conf);
 
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
   ignition::fuel_tools::LocalCache cache(&conf);
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
-
 
   ignition::fuel_tools::ServerConfig srv1;
   srv1.SetUrl(ignition::common::URI("http://localhost:8001/"));


### PR DESCRIPTION
This includes moving LocalCache.hh from public headers as a follow up to #109

Signed-off-by: Michael Carroll <michael@openrobotics.org>