### PR TITLE
Sdf from path helper

### DIFF
--- a/include/ignition/fuel_tools/Interface.hh
+++ b/include/ignition/fuel_tools/Interface.hh
@@ -37,5 +37,26 @@ namespace ignition
     /// \return Path to the downloaded asset. Empty on error.
     IGNITION_FUEL_TOOLS_VISIBLE std::string fetchResourceWithClient(
         const std::string &_uri, ignition::fuel_tools::FuelClient &_client);
+
+    /// \brief Get the SDF file path for a model or world based on a directory
+    /// containing a Fuel model or world. Here is a typical use case:
+    ///
+    ///   1. Fetch a Fuel resource:
+    ///   `std::string resourcePath = fetchResource("https://...")`
+    ///   2. Get the SDF file for the resource:
+    ///   `std::string resourceSdf = sdfFromPath(resourcePath)`
+    ///   3. Parse the SDF file using libsdformat.
+    ///
+    /// This function will determine the SDF file according to the following:
+    ///   1. Check for a metadata.pbtxt file, and return the SDF file specified
+    /// within the metadata.pbtxt file.
+    ///   2. Check for a model.config file, and return the SDF file specified
+    /// withing the model.config file.
+    ///   3. Return the first file with an `.sdf` extension.
+    /// \param[in] _path Filesystem path to a Fuel model or world directory.
+    /// \return Full path to the model or world SDF file, or empty string if
+    /// the SDF file coult not be determined.
+    IGNITION_FUEL_TOOLS_VISIBLE std::string sdfFromPath(
+        const std::string &_path);
   }
 }

--- a/src/Interface_TEST.cc
+++ b/src/Interface_TEST.cc
@@ -127,7 +127,6 @@ TEST(Interface, FetchResources)
     // Download model file
     std::string path = fetchResourceWithClient(modelFileUrl.Str(), client);
 
-
     // Check entire model was downloaded to `1`
     EXPECT_TRUE(common::exists(
         common::joinPaths("test_cache", "fuel.ignitionrobotics.org",

--- a/src/Interface_TEST.cc
+++ b/src/Interface_TEST.cc
@@ -70,6 +70,11 @@ TEST(Interface, FetchResources)
     // Download model
     std::string path = fetchResourceWithClient(modelUrl.Str(), client);
 
+    std::string sdfPath = sdfFromPath(path);
+    EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
+      "fuel.ignitionrobotics.org", "chapulina", "models", "test box", "2",
+      "model.sdf"), sdfPath);
+
     // Check it was downloaded to `2`
     EXPECT_EQ(path, common::joinPaths(common::cwd(), "test_cache",
       "fuel.ignitionrobotics.org", "chapulina", "models", "test box", "2"));
@@ -122,6 +127,7 @@ TEST(Interface, FetchResources)
     // Download model file
     std::string path = fetchResourceWithClient(modelFileUrl.Str(), client);
 
+
     // Check entire model was downloaded to `1`
     EXPECT_TRUE(common::exists(
         common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
@@ -154,7 +160,14 @@ TEST(Interface, FetchResources)
       EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
         "fuel.ignitionrobotics.org", "openrobotics", "models", "bus", "1"),
         cachedPath);
-     }
+    }
+
+    {
+      std::string sdfFile = sdfFromPath(cachedPath);
+      EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
+            "fuel.ignitionrobotics.org", "openrobotics", "models", "bus",
+            "1", "model.sdf"), sdfFile);
+    }
 
     // Check file is cached
     {
@@ -176,6 +189,8 @@ TEST(Interface, FetchResources)
       Result res = client.CachedWorld(worldUrl, cachedPath);
       EXPECT_FALSE(res) << "Cached Path: " << cachedPath;
       EXPECT_EQ(Result(ResultType::FETCH_ERROR), res);
+      std::string sdfFile = sdfFromPath(cachedPath);
+      EXPECT_TRUE(sdfFile.empty());
     }
 
     // Download world
@@ -245,7 +260,14 @@ TEST(Interface, FetchResources)
       EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
         "fuel.ignitionrobotics.org", "chapulina", "worlds", "test world", "2"),
         cachedPath);
-     }
+    }
+
+    {
+      std::string sdfFile = sdfFromPath(cachedPath);
+      EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
+            "fuel.ignitionrobotics.org", "chapulina", "worlds", "test world",
+            "2", "test.sdf"), sdfFile);
+    }
 
     // Check file is cached
     {


### PR DESCRIPTION
# 🎉 New feature


## Summary

This PR adds a helper function that return the SDF file associated with a Fuel resource. This is useful for downstream users of Fuel resources that want to parse the SDF file for a model or world.

## Test it
Run the tests.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.