### PR TITLE
Print error when unzipping fails to save a file

### DIFF
--- a/src/Zip.cc
+++ b/src/Zip.cc
@@ -168,9 +168,17 @@ bool Zip::Extract(const std::string &_src,
     if (len < 0)
       ignerr << "Error reading " << sb.name << std::endl;
     else
+    {
       file.write(buf, len);
-
-    igndbg << "Created file [" << dst << "]" << std::endl;
+      if (file.fail())
+      {
+        ignerr << "Failed to write file [" << dst << "]" << std::endl;
+      }
+      else
+      {
+        igndbg << "Created file [" << dst << "]" << std::endl;
+      }
+    }
 
     delete[] buf;
     file.close();

--- a/src/Zip.cc
+++ b/src/Zip.cc
@@ -150,6 +150,7 @@ bool Zip::Extract(const std::string &_src,
                << "Do you have the right permissions?" << std::endl;
         return false;
       }
+      continue;
     }
 
     // Create and write the files.


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

While reviewing https://github.com/ignitionrobotics/ign-gazebo/pull/1262, some files were failing to download, but I was getting success messages. This PR just makes sure that a success message isn't printed on failure.

Before this PR we get false positives:

```
$ ign fuel download -v 4 --url "https://fuel.ignitionrobotics.org/1.0/jennuine/models/Monterey Bay"          
Downloading model:                                                                                                                          
  Name: monterey bay                                                                                                                          Owner: jennuine                                                                                                                           
  Server:                                                                                                                                   
    URL: https://fuel.ignitionrobotics.org                                                                                                  
    Version: 1.0                                                                                                                            
                                                                                                                                            
[Msg] Downloading model [https://fuel.ignitionrobotics.org/jennuine/models/monterey bay]                                                    
[Dbg] [Zip.cc:176] Created file [/home/developer/.ignition/fuel/fuel.ignitionrobotics.org/jennuine/models/monterey bay/2/dem/]              
[Dbg] [Zip.cc:176] Created file [/home/developer/.ignition/fuel/fuel.ignitionrobotics.org/jennuine/models/monterey bay/2/dem/monterey_bay_gebco_2021.tif]                                                                                                                               
[Dbg] [Zip.cc:176] Created file [/home/developer/.ignition/fuel/fuel.ignitionrobotics.org/jennuine/models/monterey bay/2/materials/]        
[Dbg] [Zip.cc:176] Created file [/home/developer/.ignition/fuel/fuel.ignitionrobotics.org/jennuine/models/monterey bay/2/materials/textures/]                                                                                                                                           
[Dbg] [Zip.cc:176] Created file [/home/developer/.ignition/fuel/fuel.ignitionrobotics.org/jennuine/models/monterey bay/2/materials/textures/monterey_bay_gebco_2021_colormap.png] 
[Dbg] [Zip.cc:176] Created file [/home/developer/.ignition/fuel/fuel.ignitionrobotics.org/jennuine/models/monterey bay/2/materials/textures/monterey_bay_gebco_2021_relief.png] 
[Dbg] [Zip.cc:176] Created file [/home/developer/.ignition/fuel/fuel.ignitionrobotics.org/jennuine/models/monterey bay/2/model.config]                                                                                                       
[Dbg] [Zip.cc:176] Created file [/home/developer/.ignition/fuel/fuel.ignitionrobotics.org/jennuine/models/monterey bay/2/model.sdf]                                                                                                      
[Dbg] [Zip.cc:176] Created file [/home/developer/.ignition/fuel/fuel.ignitionrobotics.org/jennuine/models/monterey bay/2/thumbnails/]       
[Dbg] [Zip.cc:176] Created file [/home/developer/.ignition/fuel/fuel.ignitionrobotics.org/jennuine/models/monterey bay/2/thumbnails/1.png] 
```

After:

```
$ ign fuel download -v 4 --url "https://fuel.ignitionrobotics.org/1.0/jennuine/models/Monterey Bay"
Downloading model: 
  Name: monterey bay
  Owner: jennuine
  Server:
    URL: https://fuel.ignitionrobotics.org
    Version: 1.0

[Msg] Downloading model [https://fuel.ignitionrobotics.org/jennuine/models/monterey bay]
[Err] [Zip.cc:175] Failed to write file [/home/developer/.ignition/fuel/fuel.ignitionrobotics.org/jennuine/models/monterey bay/2/dem/]
[Err] [Zip.cc:175] Failed to write file [/home/developer/.ignition/fuel/fuel.ignitionrobotics.org/jennuine/models/monterey bay/2/dem/monterey_bay_gebco_2021.tif]
[Err] [Zip.cc:175] Failed to write file [/home/developer/.ignition/fuel/fuel.ignitionrobotics.org/jennuine/models/monterey bay/2/materials/]
[Err] [Zip.cc:175] Failed to write file [/home/developer/.ignition/fuel/fuel.ignitionrobotics.org/jennuine/models/monterey bay/2/materials/textures/]
[Err] [Zip.cc:175] Failed to write file [/home/developer/.ignition/fuel/fuel.ignitionrobotics.org/jennuine/models/monterey bay/2/materials/textures/monterey_bay_gebco_2021_colormap.png]
[Err] [Zip.cc:175] Failed to write file [/home/developer/.ignition/fuel/fuel.ignitionrobotics.org/jennuine/models/monterey bay/2/materials/textures/monterey_bay_gebco_2021_relief.png]
[Dbg] [Zip.cc:179] Created file [/home/developer/.ignition/fuel/fuel.ignitionrobotics.org/jennuine/models/monterey bay/2/model.config]
[Dbg] [Zip.cc:179] Created file [/home/developer/.ignition/fuel/fuel.ignitionrobotics.org/jennuine/models/monterey bay/2/model.sdf]
[Err] [Zip.cc:175] Failed to write file [/home/developer/.ignition/fuel/fuel.ignitionrobotics.org/jennuine/models/monterey bay/2/thumbnails/]
[Err] [Zip.cc:175] Failed to write file [/home/developer/.ignition/fuel/fuel.ignitionrobotics.org/jennuine/models/monterey bay/2/thumbnails/1.png]
Download succeeded.
```

PS: The issue downloading these files on Garden should be fixed by https://github.com/ignitionrobotics/ign-common/pull/308

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
