### PR TITLE
Fix trailing slash expectations in failing tests

### DIFF
--- a/src/ClientConfig_TEST.cc
+++ b/src/ClientConfig_TEST.cc
@@ -413,9 +413,9 @@ TEST(ServerConfig, Url)
   {
     ServerConfig srv;
     srv.SetUrl(common::URI("http://banana:8080/"));
-    EXPECT_EQ("http://banana:8080", srv.Url().Str());
+    EXPECT_EQ("http://banana:8080/", srv.Url().Str());
     EXPECT_EQ("http", srv.Url().Scheme());
-    EXPECT_EQ("banana:8080", srv.Url().Path().Str());
+    EXPECT_EQ("banana:8080/", srv.Url().Path().Str());
     EXPECT_FALSE(srv.Url().Authority());
   }
 

--- a/src/LocalCache_TEST.cc
+++ b/src/LocalCache_TEST.cc
@@ -351,7 +351,7 @@ TEST_F(LocalCacheTest, MatchingModel)
   ASSERT_TRUE(am1Model);
   EXPECT_EQ("alice", am1Model.Identification().Owner());
   EXPECT_EQ("am1", am1Model.Identification().Name());
-  EXPECT_EQ("http://localhost:8001",
+  EXPECT_EQ("http://localhost:8001/",
       am1Model.Identification().Server().Url().Str());
 
   ModelIdentifier tm2;
@@ -502,7 +502,7 @@ TEST_F(LocalCacheTest, MatchingWorld)
   EXPECT_TRUE(cache.MatchingWorld(am1));
   EXPECT_EQ("alice", am1.Owner());
   EXPECT_EQ("am1", am1.Name());
-  EXPECT_EQ("http://localhost:8001", am1.Server().Url().Str());
+  EXPECT_EQ("http://localhost:8001/", am1.Server().Url().Str());
 
   WorldIdentifier tm2;
   tm2.SetServer(srv1);


### PR DESCRIPTION
# 🦟 Bug fix

Fix tests that have been failing since https://github.com/ignitionrobotics/ign-common/pull/275 was merged

## Summary

From https://github.com/ignitionrobotics/ign-common/pull/275:

> The issue is that the URIPath::Implementation struct has a trailingSlash member:  https://github.com/ignitionrobotics/ign-common/blob/ign-common4/src/URI.cc#L54-L73
> The originally written copy-assignment operator doesn't copy this member:
https://github.com/ignitionrobotics/ign-common/blob/ign-common4/src/URI.cc#L586-L591
> And the test exercises this copy-assignment:
https://github.com/ignitionrobotics/ign-common/blob/ign-common4/src/URI_TEST.cc#L890-L894
> In this case, ImplPtr has shown that the previous behavior is actually a bug, and we should fix it in previous versions.

So there was a bug in handling of trailing slashes that has now been fixed, which has caused some failing tests here due to incorrect expectations. I've updated the expectations in this PR.

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_fuel-tools-ci-ign-fuel-tools6-focal-amd64&build=3)](https://build.osrfoundation.org/view/ign-edifice/job/ignition_fuel-tools-ci-ign-fuel-tools6-focal-amd64/3/) https://build.osrfoundation.org/view/ign-edifice/job/ignition_fuel-tools-ci-ign-fuel-tools6-focal-amd64/3/
* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_fuel-tools-ci-ign-fuel-tools6-homebrew-amd64&build=9)](https://build.osrfoundation.org/view/ign-edifice/job/ignition_fuel-tools-ci-ign-fuel-tools6-homebrew-amd64/9/) https://build.osrfoundation.org/view/ign-edifice/job/ignition_fuel-tools-ci-ign-fuel-tools6-homebrew-amd64/9/

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
