### PR TITLE
Move test_config to align with other packages

### DIFF
--- a/include/ignition/fuel_tools/Result.hh
+++ b/include/ignition/fuel_tools/Result.hh
@@ -93,7 +93,7 @@ namespace ignition
       public: Result();
 
       /// \brief Destructor.
-      public: ~Result();
+      public: virtual ~Result();
 
       /// \brief Constructor
       /// \param[in] _type Result type

--- a/src/ClientConfig_TEST.cc
+++ b/src/ClientConfig_TEST.cc
@@ -22,7 +22,7 @@
 #include <ignition/common/Filesystem.hh>
 #include <ignition/common/Util.hh>
 #include "ignition/fuel_tools/ClientConfig.hh"
-#include "test/test_config.h"
+#include "test_config.h"
 
 using namespace ignition;
 using namespace fuel_tools;

--- a/src/FuelClient.cc
+++ b/src/FuelClient.cc
@@ -1835,7 +1835,7 @@ bool FuelClient::UpdateModels(const std::vector<std::string> &_headers)
   }
 
   // Attempt to update each model.
-  for (const auto id : toProcess)
+  for (const auto &id : toProcess)
   {
     ignition::fuel_tools::ModelIdentifier cloudId;
 
@@ -1876,7 +1876,7 @@ bool FuelClient::UpdateWorlds(const std::vector<std::string> &_headers)
   }
 
   // Attempt to update each world.
-  for (const auto id : toProcess)
+  for (const auto &id : toProcess)
   {
     ignition::fuel_tools::WorldIdentifier cloudId;
 

--- a/src/FuelClient_TEST.cc
+++ b/src/FuelClient_TEST.cc
@@ -26,7 +26,7 @@
 #include "ignition/fuel_tools/Result.hh"
 #include "ignition/fuel_tools/WorldIdentifier.hh"
 
-#include "test/test_config.h"
+#include "test_config.h"
 
 #ifdef _WIN32
 #include <direct.h>

--- a/src/Interface_TEST.cc
+++ b/src/Interface_TEST.cc
@@ -23,7 +23,7 @@
 #include "ignition/fuel_tools/FuelClient.hh"
 #include "ignition/fuel_tools/Interface.hh"
 
-#include "test/test_config.h"
+#include "test_config.h"
 
 #ifdef _WIN32
 #include <direct.h>

--- a/src/LocalCache_TEST.cc
+++ b/src/LocalCache_TEST.cc
@@ -28,7 +28,7 @@
 #include "ignition/fuel_tools/WorldIdentifier.hh"
 
 #include "LocalCache.hh"
-#include "test/test_config.h"
+#include "test_config.h"
 
 #ifdef _WIN32
 #include <direct.h>

--- a/src/RestClient.cc
+++ b/src/RestClient.cc
@@ -133,11 +133,8 @@ struct curl_httppost *BuildFormPost(
 {
   struct curl_httppost *formpost = nullptr;
   struct curl_httppost *lastptr = nullptr;
-  for (const std::pair<std::string, std::string> &it : _form)
+  for (const auto &[key, value] : _form)
   {
-    std::string key = it.first;
-    std::string value = it.second;
-
     // follow same convention as curl cmdline tool
     // field starting with @ indicates path to file to upload
     // others are standard fields to describe the file

--- a/src/RestClient_TEST.cc
+++ b/src/RestClient_TEST.cc
@@ -18,7 +18,7 @@
 #include <gtest/gtest.h>
 #include <string>
 #include "ignition/fuel_tools/RestClient.hh"
-#include "test/test_config.h"
+#include "test_config.h"
 
 /////////////////////////////////////////////////
 TEST(RestClient, UserAgent)

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -23,7 +23,7 @@
 #include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/fuel_tools/config.hh"
-#include "test/test_config.h"  // NOLINT(build/include)
+#include "test_config.h"
 
 /////////////////////////////////////////////////
 std::string custom_exec_str(std::string _cmd)

--- a/src/ign_src_TEST.cc
+++ b/src/ign_src_TEST.cc
@@ -24,7 +24,7 @@
 #include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ign.hh"
-#include "test/test_config.h"  // NOLINT(build/include)
+#include "test_config.h"
 
 using namespace ignition;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,25 +1,23 @@
-include_directories (
-  ${PROJECT_SOURCE_DIR}/test/gtest/include
-  ${PROJECT_SOURCE_DIR}/test/gtest
-  ${PROJECT_SOURCE_DIR}/test
-  ${PROJECT_BINARY_DIR}
-)
-
-configure_file (test_config.h.in ${PROJECT_BINARY_DIR}/test/test_config.h)
+configure_file(test_config.h.in ${PROJECT_BINARY_DIR}/test_config.h)
 
 # Build gtest
 add_library(gtest STATIC gtest/src/gtest-all.cc)
 add_library(gtest_main STATIC gtest/src/gtest_main.cc)
-target_link_libraries(
-  gtest_main gtest
-  ignition-cmake${IGN_CMAKE_VER}::utilities
+target_include_directories(gtest
+  SYSTEM PUBLIC
+  ${PROJECT_SOURCE_DIR}/test/gtest/include
+  PRIVATE
+  ${PROJECT_SOURCE_DIR}/test/gtest
 )
+
+target_link_libraries(gtest_main gtest)
+set_property(TARGET gtest_main PROPERTY CXX_STANDARD ${c++standard})
+set_property(TARGET gtest PROPERTY CXX_STANDARD ${c++standard})
 set(GTEST_LIBRARY "${PROJECT_BINARY_DIR}/test/libgtest.a")
 set(GTEST_MAIN_LIBRARY "${PROJECT_BINARY_DIR}/test/libgtest_main.a")
 
 execute_process(COMMAND cmake -E remove_directory ${CMAKE_BINARY_DIR}/test_results)
 execute_process(COMMAND cmake -E make_directory ${CMAKE_BINARY_DIR}/test_results)
-include_directories(${GTEST_INCLUDE_DIRS})
 
 add_subdirectory(integration)
 add_subdirectory(performance)

--- a/test/integration/zip.cc
+++ b/test/integration/zip.cc
@@ -21,7 +21,7 @@
 #include <ignition/common/Filesystem.hh>
 
 #include "ignition/fuel_tools/Zip.hh"
-#include "test/test_config.h"
+#include "test_config.h"
 
 using namespace ignition;
 using namespace fuel_tools;


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

This moves the generated `test_config.h` to not be in `test`, which brings it in line with the rest of the ignition packages.

It also rearranges a bit of the gtest cmake logic so that the targets/includes are more explicit.


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.