### PR TITLE
Fixed from source install command for ign-fuel-tools7

### DIFF
--- a/tutorials/01_installation.md
+++ b/tutorials/01_installation.md
@@ -93,7 +93,7 @@ sudo apt-get install git cmake pkg-config python ruby-ronn libignition-cmake2-de
 Clone the repository into a directory and go into it:
 
 ```
-git clone https://github.com/gazbosim/gz-fuel-tools /tmp/gz-fuel-tools
+git clone https://github.com/gazbosim/gz-fuel-tools /tmp/gz-fuel-tools -b ign-fuel-tools7
 cd /tmp/gz-fuel-tools
 ```
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Newer gz-fuel-tools tutorials already contain a notice that a branch should be selected. The ign-fuel-tools7 tutorial is missing this.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
