### PR TITLE
Add a flag --skip-cached to skip already-downloaded models and collections

### DIFF
--- a/src/cmd/cmdfuel.rb.in
+++ b/src/cmd/cmdfuel.rb.in
@@ -126,7 +126,8 @@ SUBCOMMANDS = {
   "  -t [--type] arg          Limit what resource type (i.e. model, world) \n"\
   "                           to download from a collection. All resources \n"\
   "                           will be downloaded if unspecified. Ignored   \n"\
-  "                           if not downloading collection.               \n"+
+  "                           if not downloading collection.               \n"\
+  "  -s [--skip-cached]       Skip downloading resources already in cache. \n"+
   COMMON_OPTIONS,
 
  'edit' =>
@@ -228,7 +229,8 @@ class Cmd
       'onlymodels' => '0',
       'onlyworlds' => '0',
       'defaults' => false,
-      'console' => false
+      'console' => false,
+      'skip_cached' => 'false'
     }
 
     usage = COMMANDS[args[0]]
@@ -301,6 +303,9 @@ class Cmd
       end
       opts.on('--console', 'Output to console') do
         options['console'] = true
+      end
+      opts.on('-s', '--skip-cached', 'Skip downloading resources already in cache') do
+        options['skip_cached'] = 'true'
       end
     end # opt_parser do
 
@@ -434,9 +439,9 @@ class Cmd
           exit(-1)
         end
       when 'download'
-        Importer.extern 'int downloadUrl(const char *, const  char *, const char *, const char *, unsigned int)'
+        Importer.extern 'int downloadUrl(const char *, const  char *, const char *, const char *, unsigned int, const char *)'
         if not Importer.downloadUrl(options['url'], options['config'],
-            options['header'], options['type'], options['jobs_int'])
+            options['header'], options['type'], options['jobs_int'], options['skip_cached'])
           exit(-1)
         end
       when 'edit'

--- a/src/cmd/fuel.bash_completion.sh
+++ b/src/cmd/fuel.bash_completion.sh
@@ -55,6 +55,7 @@ GZ_DOWNLOAD_COMPLETION_LIST="
   -j --jobs
   -t --type
   -u --url
+  -s --skip-cached
   --force-version
   --versions
 "

--- a/src/gz.hh
+++ b/src/gz.hh
@@ -46,6 +46,7 @@ extern "C" GZ_FUEL_TOOLS_VISIBLE int listModels(
 /// \param[in] _owner Optional owner name
 /// \param[in] _raw 'true' for machine readable output.
 /// \param[in] _configFile Path to a YAML configuration file.
+/// \param[in] _skipCached "true" to skip resources already in cache.
 /// \return 1 if successful, 0 if not.
 extern "C" GZ_FUEL_TOOLS_VISIBLE int listWorlds(
     const char *_url = nullptr, const char *_owner = "",
@@ -61,7 +62,7 @@ extern "C" GZ_FUEL_TOOLS_VISIBLE int listWorlds(
 /// \return 1 if successful, 0 if not.
 extern "C" GZ_FUEL_TOOLS_VISIBLE int downloadUrl(
     const char *_url = nullptr, const char *_configFile = nullptr,
-    const char *_header = nullptr, const char *_type = nullptr, int _jobs = 1);
+    const char *_header = nullptr, const char *_type = nullptr, int _jobs = 1, const char *_skipCached = "false");
 
 /// \brief External hook to execute 'gz fuel upload -m path' from the command
 /// line.


### PR DESCRIPTION
# 🎉 New feature

Closes #150 

## Summary
This PR introduces a `--skip-cached` flag option to **gz-fuel-tools10** (available through the `gz fuel download` command).  
When the flag is set, any models that already exist in the local cache are **skipped instead of downloaded again**, saving time.

Both **individual model downloads** and **collection downloads** now respect this flag.

### Behaviour before this PR
Every time running of `gz fuel download` re-download of all models, even if they were already present locally.

### Behaviour after this PR
With `--skip-cached`, the CLI first checks the local cache and only downloads the models that are missing.


## Test it
<!--Explain how reviewers can test this new feature manually.-->
1. Start a large collection download and interrupt it Press Ctrl+C partway through

```bash
gz fuel download -j 4  -u "https://fuel.gazebosim.org/1.0/openrobotics/collections/Gazebo classic model database"
```
![Screenshot from 2025-04-25 02-11-25](https://github.com/user-attachments/assets/5dc42aa1-349e-4814-98a7-dcba5de318b3)

2. Resume with the new flag – already-downloaded models are skipped

```bash
gz fuel download -j 4 --skip-cached -u "https://fuel.gazebosim.org/1.0/openrobotics/collections/Gazebo classic model database"
```
![Screenshot from 2025-04-25 02-00-33](https://github.com/user-attachments/assets/0a221426-2982-4169-aaf4-13352ed7947c)


You can repeat the same steps with an individual model URL too.

```bash
gz fuel download -u https://fuel.gazebosim.org/1.0/OpenRobotics/models/Ambulance -v 4
````
```bash
gz fuel download -u --skip-cached https://fuel.gazebosim.org/1.0/OpenRobotics/models/Ambulance -v 4
```

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.