### PR TITLE
Backport warning fix

### DIFF
--- a/src/RestClient.cc
+++ b/src/RestClient.cc
@@ -133,11 +133,8 @@ struct curl_httppost *BuildFormPost(
 {
   struct curl_httppost *formpost = nullptr;
   struct curl_httppost *lastptr = nullptr;
-  for (const std::pair<std::string, std::string> &it : _form)
+  for (const auto &[key, value] : _form)
   {
-    std::string key = it.first;
-    std::string value = it.second;
-
     // follow same convention as curl cmdline tool
     // field starting with @ indicates path to file to upload
     // others are standard fields to describe the file


### PR DESCRIPTION
# 🦟 Bug fix

Backports fix from #246.

## Summary

Originally fixed by 2cdad7fb0 in #246.
Original message:
~~~
Clean a few warnings caught by clang
~~~

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_fuel_tools-ci-ign-fuel-tools7-jammy-amd64&build=4)](https://build.osrfoundation.org/job/gz_fuel_tools-ci-ign-fuel-tools7-jammy-amd64/4/) https://build.osrfoundation.org/job/gz_fuel_tools-ci-ign-fuel-tools7-jammy-amd64/4/gcc/

~~~
src/RestClient.cc:136:51: warning: loop variable ‘it’ of type ‘const std::pair<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >&’ binds to a temporary constructed from type ‘const std::pair<const std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >’ [-Wrange-loop-construct]
22:08:58   136 |   for (const std::pair<std::string, std::string> &it : _form)
22:08:58       |                                                   ^~
~~~

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
