### PR TITLE
Fix unused result warnings

### DIFF
--- a/src/FuelClient.cc
+++ b/src/FuelClient.cc
@@ -766,7 +766,12 @@ Result FuelClient::ModelDependencies(const ModelIdentifier &_id,
       if (foundMetadataPath)
       {
         // Parse the file into the fuel metadata message
-        google::protobuf::TextFormat::ParseFromString(inputStr, &meta);
+        if (!google::protobuf::TextFormat::ParseFromString(inputStr, &meta))
+        {
+          gzerr << "Unable to parse fuel metadata message ["
+                << modelPath << "]" << std::endl;
+          return Result(ResultType::FETCH_ERROR);
+        }
       }
       else
       {
@@ -1706,7 +1711,12 @@ bool FuelClientPrivate::FillModelForm(const std::string &_pathToModelDir,
         std::istreambuf_iterator<char>());
 
     // Parse the file into the fuel metadata message
-    google::protobuf::TextFormat::ParseFromString(inputStr, &meta);
+    if (!google::protobuf::TextFormat::ParseFromString(inputStr, &meta))
+    {
+      gzerr << "Unable to parse fuel metadata message [" << filePath << ']'
+            << std::endl;
+      return false;
+    }
   }
   else if (common::exists(common::joinPaths(_pathToModelDir, "model.config")))
   {

--- a/src/Interface.cc
+++ b/src/Interface.cc
@@ -111,7 +111,8 @@ namespace gz::fuel_tools
       if (foundMetadataPath)
       {
         // Parse the file into the fuel metadata message
-        google::protobuf::TextFormat::ParseFromString(inputStr, &meta);
+        if (!google::protobuf::TextFormat::ParseFromString(inputStr, &meta))
+          return "";
       }
       else
       {

--- a/src/gz.cc
+++ b/src/gz.cc
@@ -803,7 +803,11 @@ extern "C" GZ_FUEL_TOOLS_VISIBLE int pbtxt2Config(const char *_path)
       std::istreambuf_iterator<char>());
 
   // Parse the file into the fuel metadata message
-  google::protobuf::TextFormat::ParseFromString(inputStr, &meta);
+  if (!google::protobuf::TextFormat::ParseFromString(inputStr, &meta))
+  {
+    std::cerr << "Unable to parse Fuel metadata from [" << _path << "]\n";
+    return 0;
+  }
 
   std::string modelConfig;
   if (!gz::msgs::ConvertFuelMetadata(meta, modelConfig))


### PR DESCRIPTION
# 🦟 Bug fix

Fixes compiler warnings, related to https://github.com/gazebosim/gz-transport/issues/810

## Summary

As noted in the [protobuf 34.0 release notes](https://github.com/protocolbuffers/protobuf/releases/tag/v34.0) [[nodiscard]] has been added to many APIs, which is causing several unused-result compiler warnings in this package:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_fuel_tools-ci-gz-fuel-tools11-homebrew-arm64&build=48)](https://build.osrfoundation.org/job/gz_fuel_tools-ci-gz-fuel-tools11-homebrew-arm64/48/) https://build.osrfoundation.org/job/gz_fuel_tools-ci-gz-fuel-tools11-homebrew-arm64/48/clang/

This checks the result of each affected API to fix the compiler warnings, matching the error response strategy used in nearby code for each instance.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
