### PR TITLE
Fix test YAML config library_path to match Ruby script location

### DIFF
--- a/conf/CMakeLists.txt
+++ b/conf/CMakeLists.txt
@@ -1,11 +1,15 @@
-set(gz_library_path "${CMAKE_BINARY_DIR}/src/cmd/cmdfuel${PROJECT_VERSION_MAJOR}")
+set(gz_library_path "${CMAKE_BINARY_DIR}/test/lib/$<CONFIG>/ruby/gz/cmdfuel${PROJECT_VERSION_MAJOR}")
 
 # Generate a configuration file for internal testing.
 # Note that the major version of the library is included in the name.
 # Ex: fuel0.yaml
 configure_file(
   "fuel.yaml.in"
-    "${CMAKE_BINARY_DIR}/test/conf/fuel${PROJECT_VERSION_MAJOR}.yaml" @ONLY)
+    "${CMAKE_CURRENT_BINARY_DIR}/fuel${PROJECT_VERSION_MAJOR}.yaml.configured" @ONLY)
+
+file(GENERATE
+  OUTPUT "${CMAKE_BINARY_DIR}/test/conf/$<CONFIG>/fuel${PROJECT_VERSION_MAJOR}.yaml"
+  INPUT "${CMAKE_CURRENT_BINARY_DIR}/fuel${PROJECT_VERSION_MAJOR}.yaml.configured")
 
 set(gz_library_path "${CMAKE_INSTALL_PREFIX}/lib/ruby/gz/cmdfuel${PROJECT_VERSION_MAJOR}")
 

--- a/conf/CMakeLists.txt
+++ b/conf/CMakeLists.txt
@@ -1,11 +1,15 @@
-set(gz_library_path "${CMAKE_BINARY_DIR}/src/cmd/cmdfuel${PROJECT_VERSION_MAJOR}")
+set(gz_library_path "${CMAKE_BINARY_DIR}/test/lib/$<CONFIG>/ruby/gz/cmdfuel${PROJECT_VERSION_MAJOR}")
 
 # Generate a configuration file for internal testing.
 # Note that the major version of the library is included in the name.
 # Ex: fuel0.yaml
 configure_file(
   "fuel.yaml.in"
-    "${CMAKE_BINARY_DIR}/test/conf/fuel${PROJECT_VERSION_MAJOR}.yaml" @ONLY)
+    "${CMAKE_CURRENT_BINARY_DIR}/fuel${PROJECT_VERSION_MAJOR}.yaml.configured" @ONLY)
+
+file(GENERATE
+  OUTPUT "${CMAKE_BINARY_DIR}/test/conf/fuel${PROJECT_VERSION_MAJOR}.yaml"
+  INPUT "${CMAKE_CURRENT_BINARY_DIR}/fuel${PROJECT_VERSION_MAJOR}.yaml.configured")
 
 set(gz_library_path "${CMAKE_INSTALL_PREFIX}/lib/ruby/gz/cmdfuel${PROJECT_VERSION_MAJOR}")
 

--- a/conf/CMakeLists.txt
+++ b/conf/CMakeLists.txt
@@ -8,7 +8,7 @@ configure_file(
     "${CMAKE_CURRENT_BINARY_DIR}/fuel${PROJECT_VERSION_MAJOR}.yaml.configured" @ONLY)
 
 file(GENERATE
-  OUTPUT "${CMAKE_BINARY_DIR}/test/conf/fuel${PROJECT_VERSION_MAJOR}.yaml"
+  OUTPUT "${CMAKE_BINARY_DIR}/test/conf/$<CONFIG>/fuel${PROJECT_VERSION_MAJOR}.yaml"
   INPUT "${CMAKE_CURRENT_BINARY_DIR}/fuel${PROJECT_VERSION_MAJOR}.yaml.configured")
 
 set(gz_library_path "${CMAKE_INSTALL_PREFIX}/lib/ruby/gz/cmdfuel${PROJECT_VERSION_MAJOR}")


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

The test YAML configuration file (`test/conf/fuel<N>.yaml`) sets `library_path` to `src/cmd/cmdfuel<N>`, but the test Ruby command script is actually generated at `test/lib/<CONFIG>/ruby/gz/cmdfuel<N>` by `src/cmd/CMakeLists.txt`. This path mismatch means running `gz fuel` from the build tree using the test config fails to locate the Ruby library.

Since the corrected path includes the `$<CONFIG>` generator expression (required for multi-config generators like Visual Studio and Xcode), this PR switches the test YAML generation from a single `configure_file()` call to the two-step `configure_file()` + `file(GENERATE)` pattern already used in `src/cmd/CMakeLists.txt`. The `file(GENERATE)` `OUTPUT` path also includes `$<CONFIG>` so that on multi-config generators each configuration writes to its own file, avoiding the "Evaluation file to be written multiple times with different content" CMake error.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Claude Code

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
